### PR TITLE
Rio threadpool

### DIFF
--- a/samples/Channels.Samples/HttpServer/HttpServer.cs
+++ b/samples/Channels.Samples/HttpServer/HttpServer.cs
@@ -53,7 +53,15 @@ namespace Channels.Samples.Http
         private void StartAcceptingRIOConnections<TContext>(IHttpApplication<TContext> application, IPAddress ip, int port)
         {
             var addressBytes = ip.GetAddressBytes();
-            _rioTcpServer = new RioTcpServer((ushort)port, addressBytes[0], addressBytes[1], addressBytes[2], addressBytes[3]);
+
+            try
+            {
+                _rioTcpServer = new RioTcpServer((ushort)port, addressBytes[0], addressBytes[1], addressBytes[2], addressBytes[3]);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
 
             while (true)
             {

--- a/samples/Channels.Samples/HttpServer/HttpServer.cs
+++ b/samples/Channels.Samples/HttpServer/HttpServer.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Channels.Networking.Libuv;
 using Channels.Networking.Windows.RIO;
@@ -34,8 +35,8 @@ namespace Channels.Samples.Http
             int port;
             GetIp(address, out ip, out port);
             Task.Run(() => StartAcceptingLibuvConnections(application, ip, port));
-            // Task.Run(() => StartAcceptingRIOConnections(application, ip, port));
-            // Task.Run(() => StartAcceptingConnections(application, ip, port));
+            // Task.Factory.StartNew(() => StartAcceptingRIOConnections(application, ip, port), TaskCreationOptions.LongRunning);
+            // Task.Factory.StartNew(() => StartAcceptingConnections(application, ip, port), TaskCreationOptions.LongRunning);
         }
 
         private void StartAcceptingLibuvConnections<TContext>(IHttpApplication<TContext> application, IPAddress ip, int port)
@@ -52,6 +53,7 @@ namespace Channels.Samples.Http
 
         private void StartAcceptingRIOConnections<TContext>(IHttpApplication<TContext> application, IPAddress ip, int port)
         {
+            Thread.CurrentThread.Name = "RIO Accept Thread";
             var addressBytes = ip.GetAddressBytes();
 
             try
@@ -68,7 +70,7 @@ namespace Channels.Samples.Http
                 try
                 {
                     var connection = _rioTcpServer.Accept();
-                    var task = Task.Factory.StartNew(() => ProcessRIOConnection(application, connection));
+                    var task = ProcessRIOConnection(application, connection);
                 }
                 catch (ObjectDisposedException)
                 {
@@ -84,6 +86,7 @@ namespace Channels.Samples.Http
 
         private async void StartAcceptingConnections<TContext>(IHttpApplication<TContext> application, IPAddress ip, int port)
         {
+            Thread.CurrentThread.Name = "Socket Accept Thread";
             _listenSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             _listenSocket.Bind(new IPEndPoint(ip, port));
             _listenSocket.Listen(10);
@@ -98,7 +101,7 @@ namespace Channels.Samples.Http
                     {
                         var clientSocket = await _listenSocket.AcceptAsync();
                         clientSocket.NoDelay = true;
-                        var task = Task.Factory.StartNew(() => ProcessConnection(application, channelFactory, clientSocket));
+                        var task = ProcessConnection(application, channelFactory, clientSocket);
                     }
                     catch (ObjectDisposedException)
                     {

--- a/samples/Channels.Samples/project.json
+++ b/samples/Channels.Samples/project.json
@@ -32,5 +32,11 @@
 
   "frameworks": {
     "netcoreapp1.0": { }
+  },
+
+  "runtimeOptions": {
+    "configProperties": {
+      "System.GC.Server": true
+    }
   }
 }

--- a/src/Channels.Networking.Windows.RIO/Internal/CpuInfo.cs
+++ b/src/Channels.Networking.Windows.RIO/Internal/CpuInfo.cs
@@ -1,0 +1,272 @@
+﻿// Copyright (c) Illyriad Games. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Channels.Networking.Windows.RIO.Internal
+{
+    public static class CpuInfo
+    {
+        const string Kernel_32 = "Kernel32";
+        const int ErrorInsufficientBuffer = 0x7A;
+        private static readonly int SLPISize = Marshal.SizeOf<SystemLogicalProcessorInformation>();
+
+        private static int _numaNodeCount;
+        private static ulong _physicalCoreMask;
+        private static ulong _secondaryCoreMask;
+        private static int _physicalCoreCount;
+        private static int _logicalProcessorCount;
+        private static int _processorL1CacheCount;
+        private static int _processorL2CacheCount;
+        private static int _processorL3CacheCount;
+        private static int _processorPackageCount;
+
+        public static int PhysicalCoreCount => _physicalCoreCount != 0 ? _physicalCoreCount : GetPhysicalProcessorCount();
+        public static int LogicalProcessorCount => _logicalProcessorCount != 0 ? _logicalProcessorCount : GetLogicalProcessorCount();
+        public static ulong PhysicalCoreMask => _physicalCoreMask != 0 ? _physicalCoreMask : GetPhysicalProcessorMask();
+        public static ulong SecondaryCoreMask => _secondaryCoreMask != 0 ? _secondaryCoreMask : GetSecondaryProcessorMask();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int GetPhysicalProcessorCount()
+        {
+            QueryCpuInfo();
+            return _physicalCoreCount;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int GetLogicalProcessorCount()
+        {
+            QueryCpuInfo();
+            return _logicalProcessorCount;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ulong GetPhysicalProcessorMask()
+        {
+            QueryCpuInfo();
+            return _physicalCoreMask;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ulong GetSecondaryProcessorMask()
+        {
+            QueryCpuInfo();
+            return _secondaryCoreMask;
+        }
+
+        private static int CountSetBits(ulong bitMask)
+        {
+            const int lshift = sizeof(ulong) * 8 - 1;
+            var bitSetCount = 0;
+
+            for (var i = 0; i <= lshift; i++)
+            {
+                var bitTest = 1UL << i;
+                bitSetCount += ((bitMask & bitTest) == bitTest ? 1 : 0);
+            }
+
+            return bitSetCount;
+        }
+
+        private static ulong FirstSetBit(ulong bitMask)
+        {
+            const int lshift = sizeof(ulong) * 8 - 1;
+
+            for (var i = 0; i <= lshift; i++)
+            {
+                var bitTest = 1UL << i;
+
+                if ((bitMask & bitTest) == bitTest)
+                {
+                    return bitTest;
+                }
+            }
+
+            return 0;
+        }
+
+        private static ulong SecondSetBit(ulong bitMask)
+        {
+            const int lshift = sizeof(ulong) * 8 - 1;
+
+            var isFirst = true;
+            for (var i = 0; i <= lshift; i++)
+            {
+                var bitTest = 1UL << i;
+
+                if ((bitMask & bitTest) == bitTest)
+                {
+                    if (isFirst)
+                    {
+                        isFirst = false;
+                        continue;
+                    }
+
+                    return bitTest;
+                }
+            }
+
+            return 0;
+        }
+
+        private static unsafe void QueryCpuInfo()
+        {
+            uint returnLength = 1;
+
+            while (true)
+            {
+                var buffer = stackalloc byte[(int)returnLength];
+                if (!GetLogicalProcessorInformation(new IntPtr(buffer), ref returnLength))
+                {
+                    var error = GetLastError();
+                    if (error == 0 || error == ErrorInsufficientBuffer)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        throw new Exception();
+                    }
+                }
+
+                var byteOffset = 0;
+                while (byteOffset + SLPISize <= returnLength)
+                {
+                    var slpi = Unsafe.Read<SystemLogicalProcessorInformation>(buffer + byteOffset);
+
+                    switch (slpi.Relationship)
+                    {
+                        case LogicalProcessorRelationship.RelationNumaNode:
+                            // Non-NUMA systems report a single record of this type.
+                            _numaNodeCount++;
+                            break;
+
+                        case LogicalProcessorRelationship.RelationProcessorCore:
+                            _physicalCoreCount++;
+
+                            // A hyperthreaded core supplies more than one logical processor.
+                            var mask = slpi.ProcessorMask;
+                            var bits = CountSetBits(mask);
+                            _logicalProcessorCount += bits;
+
+                            if (bits == 1)
+                            {
+                                _physicalCoreMask |= mask;
+                                _secondaryCoreMask |= mask;
+                            }
+                            else
+                            {
+                                _physicalCoreMask |= FirstSetBit(mask);
+                                _secondaryCoreMask |= SecondSetBit(mask);
+                            }
+
+                            break;
+
+                        case LogicalProcessorRelationship.RelationCache:
+                            // Cache data is in ptr->Cache, one CACHE_DESCRIPTOR structure for each cache. 
+                            var cache = slpi.Info.Cache;
+                            if (cache.Level == 1)
+                            {
+                                _processorL1CacheCount++;
+                            }
+                            else if (cache.Level == 2)
+                            {
+                                _processorL2CacheCount++;
+                            }
+                            else if (cache.Level == 3)
+                            {
+                                _processorL3CacheCount++;
+                            }
+                            break;
+
+                        case LogicalProcessorRelationship.RelationProcessorPackage:
+                            // Logical processors share a physical package.
+                            _processorPackageCount++;
+                            break;
+
+                        default:
+                            throw new Exception("Error: Unsupported LOGICAL_PROCESSOR_RELATIONSHIP value.");
+                    }
+                    byteOffset += SLPISize;
+                }
+
+                break;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SystemLogicalProcessorInformation
+        {
+            public ulong ProcessorMask;
+            public LogicalProcessorRelationship Relationship;
+            public ProcessorInfo Info;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct ProcessorInfo
+        {
+            [FieldOffset(0)]
+            public ProcessorCore ProcessorCore;
+            [FieldOffset(0)]
+            public Node NumaNode;
+            [FieldOffset(0)]
+            public CacheDescriptor Cache;
+            [FieldOffset(0)]
+            public Reserved Reserved;
+        }
+
+        public enum LogicalProcessorRelationship
+        {
+            RelationProcessorCore,
+            RelationNumaNode,
+            RelationCache,
+            RelationProcessorPackage
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ProcessorCore
+        {
+            public byte Flags;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Reserved
+        {
+            public ulong Reserved0;
+            public ulong Reserved1;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Node
+        {
+            public uint NodeNumber;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct CacheDescriptor
+        {
+            public byte Level;
+            public byte Associativity;
+            public ushort LineSize;
+            public uint Size;
+            public ProcessorCacheType Type;
+        }
+
+        public enum ProcessorCacheType
+        {
+            CacheUnified,
+            CacheInstruction,
+            CacheData,
+            CacheTrace
+        }
+
+        [DllImport(Kernel_32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetLogicalProcessorInformation(IntPtr Buffer, ref uint returnedLength);
+
+        [DllImport(Kernel_32, SetLastError = true)]
+        private static extern long GetLastError();
+    }
+}

--- a/src/Channels.Networking.Windows.RIO/Internal/Winsock/RioDelegates.cs
+++ b/src/Channels.Networking.Windows.RIO/Internal/Winsock/RioDelegates.cs
@@ -3,27 +3,35 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Security;
 
 namespace Channels.Networking.Windows.RIO.Internal.Winsock
 {
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate IntPtr RioRegisterBuffer([In] IntPtr dataBuffer, [In] UInt32 dataLength);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate void RioDeregisterBuffer([In] IntPtr bufferId);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate bool RioSend([In] IntPtr socketQueue, [In] ref RioBufferSegment rioBuffer, [In] UInt32 dataBufferCount, [In] RioSendFlags flags, [In] long requestCorrelation);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate bool RioReceive([In] IntPtr socketQueue, [In] ref RioBufferSegment rioBuffer, [In] UInt32 dataBufferCount, [In] RioReceiveFlags flags, [In] long requestCorrelation);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate IntPtr RioCreateCompletionQueue([In] uint queueSize, [In] NotificationCompletion notificationCompletion);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate void RioCloseCompletionQueue([In] IntPtr cq);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate IntPtr RioCreateRequestQueue(
                                     [In] IntPtr socket,
@@ -36,15 +44,19 @@ namespace Channels.Networking.Windows.RIO.Internal.Winsock
                                     [In] long connectionCorrelation
                                 );
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate uint RioDequeueCompletion([In] IntPtr cq, [In] IntPtr resultArray, [In] uint resultArrayLength);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate Int32 RioNotify([In] IntPtr cq);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate bool RioResizeCompletionQueue([In] IntPtr cq, [In] UInt32 queueSize);
 
+    [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate bool RioResizeRequestQueue([In] IntPtr rq, [In] UInt32 maxOutstandingReceive, [In] UInt32 maxOutstandingSend);
 

--- a/src/Channels.Networking.Windows.RIO/Internal/Winsock/SuppressUnmanagedCodeSecurityAttribute.cs
+++ b/src/Channels.Networking.Windows.RIO/Internal/Winsock/SuppressUnmanagedCodeSecurityAttribute.cs
@@ -1,0 +1,9 @@
+﻿
+#if !NET451 
+namespace System.Security
+{
+    public class SuppressUnmanagedCodeSecurityAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/src/Channels.Networking.Windows.RIO/project.json
+++ b/src/Channels.Networking.Windows.RIO/project.json
@@ -21,7 +21,10 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0",
         "System.Threading.Thread": "4.0.0",
-        "System.Threading.Overlapped": "4.0.1"
+        "System.Threading.Overlapped": "4.0.1",
+        "System.Threading.ThreadPool": "4.0.10",
+        "System.Diagnostics.Process": "4.1.0",
+        "System.Runtime.CompilerServices.Unsafe": "4.0.0"
       }
     }
   }


### PR DESCRIPTION
- Better initalization
- Report error when can't bind
- Don't dispatch Accepts
- Use regular Dictionaries for Connections and buffer mappings
- Affinitize RIO threads to physical cores (don't count logical cores)
- HT aware for (use logical cores for read+send processing)
- Trigger completion port once per cycle
- General goodness
- Split read and flush
