### PR TITLE
RIO go faster stripes

### DIFF
--- a/src/Channels.Networking.Windows.RIO/Internal/Winsock/RIOImports.cs
+++ b/src/Channels.Networking.Windows.RIO/Internal/Winsock/RIOImports.cs
@@ -80,6 +80,7 @@ namespace Channels.Networking.Windows.RIO.Internal.Winsock
 
             rioFunctions.RioReceive = Marshal.GetDelegateForFunctionPointer<RioReceive>(rio.RIOReceive);
             rioFunctions.Send = Marshal.GetDelegateForFunctionPointer<RioSend>(rio.RIOSend);
+            rioFunctions.RioSendCommit = Marshal.GetDelegateForFunctionPointer<RioSendCommit>(rio.RIOSend);
 
             rioFunctions.CloseCompletionQueue = Marshal.GetDelegateForFunctionPointer<RioCloseCompletionQueue>(rio.RIOCloseCompletionQueue);
             rioFunctions.DeregisterBuffer = Marshal.GetDelegateForFunctionPointer<RioDeregisterBuffer>(rio.RIODeregisterBuffer);

--- a/src/Channels.Networking.Windows.RIO/Internal/Winsock/RegisteredIO.cs
+++ b/src/Channels.Networking.Windows.RIO/Internal/Winsock/RegisteredIO.cs
@@ -13,6 +13,7 @@ namespace Channels.Networking.Windows.RIO.Internal.Winsock
 
         public RioReceive RioReceive;
         public RioSend Send;
+        public RioSendCommit RioSendCommit;
 
         public RioNotify Notify;
 

--- a/src/Channels.Networking.Windows.RIO/Internal/Winsock/RioDelegates.cs
+++ b/src/Channels.Networking.Windows.RIO/Internal/Winsock/RioDelegates.cs
@@ -21,6 +21,10 @@ namespace Channels.Networking.Windows.RIO.Internal.Winsock
 
     [SuppressUnmanagedCodeSecurity]
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
+    public unsafe delegate bool RioSendCommit([In] IntPtr socketQueue, [In] RioBufferSegment* rioBuffer, [In] UInt32 dataBufferCount, [In] RioSendFlags flags, [In] long requestCorrelation);
+
+    [SuppressUnmanagedCodeSecurity]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     public delegate bool RioReceive([In] IntPtr socketQueue, [In] ref RioBufferSegment rioBuffer, [In] UInt32 dataBufferCount, [In] RioReceiveFlags flags, [In] long requestCorrelation);
 
     [SuppressUnmanagedCodeSecurity]

--- a/src/Channels.Networking.Windows.RIO/RioTcpConnection.cs
+++ b/src/Channels.Networking.Windows.RIO/RioTcpConnection.cs
@@ -38,6 +38,7 @@ namespace Channels.Networking.Windows.RIO
 
         private ReadableBuffer _sendingBuffer;
         private WritableBuffer _buffer;
+        private InvalidOperationException _error;
 
         internal RioTcpConnection(IntPtr socket, long connectionId, IntPtr requestQueue, RioThread rioThread, RegisteredIO rio)
         {
@@ -149,12 +150,30 @@ namespace Channels.Networking.Windows.RIO
 
         private void Send(RioBufferSegment segment, bool flushSends)
         {
+            if (_error != null)
+            {
+                ThrowError();
+            }
+
             var sendCorrelation = flushSends ? CompleteSendCorrelation() : PartialSendCorrelation;
-            var sendFlags = flushSends ? MessageEnd : MessagePart;
+            var sendFlags = flushSends ? RioSendFlags.Defer : MessagePart;
 
             if (!_rio.Send(_requestQueue, ref segment, 1, sendFlags, sendCorrelation))
             {
                 ThrowError(ErrorType.Send);
+            }
+
+            if (flushSends)
+            {
+                ThreadPool.QueueUserWorkItem((o) => ((RioTcpConnection)o).CommitSend(), this);
+            }
+        }
+
+        private unsafe void CommitSend()
+        {
+            if (!_rio.RioSendCommit(_requestQueue, null, 0, RioSendFlags.CommitOnly, 0))
+            {
+                _error = GetError(ErrorType.Send);
             }
         }
 
@@ -225,6 +244,16 @@ namespace Channels.Networking.Windows.RIO
 
         private static void ThrowError(ErrorType type)
         {
+            throw GetError(type);
+        }
+
+        private void ThrowError()
+        {
+            throw _error;
+        }
+
+        private static InvalidOperationException GetError(ErrorType type)
+        {
             var errorNo = RioImports.WSAGetLastError();
 
             string errorMessage;
@@ -250,7 +279,7 @@ namespace Channels.Networking.Windows.RIO
                     break;
             }
 
-            throw new InvalidOperationException(errorMessage);
+            return new InvalidOperationException(errorMessage);
         }
 
         private void Dispose(bool disposing)


### PR DESCRIPTION
Don't want to dispatch to threadpool, but its a starter for 10

![](https://aoa.blob.core.windows.net/aspnet/commitsend.png)

Splitting it off to its own delegate for profiling breakdown (RioSendCommit)

![](https://aoa.blob.core.windows.net/aspnet/commitsend-1.png)
