### PR TITLE
CommitBytes shouldn't do anything if committing zero bytes

### DIFF
--- a/src/Channels/WritableBuffer.cs
+++ b/src/Channels/WritableBuffer.cs
@@ -178,7 +178,8 @@ namespace Channels
 
                 _tail.End = blockIndex;
                 _tailIndex = blockIndex;
-            } else if (bytesWritten < 0)
+            }
+            else if (bytesWritten < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(bytesWritten));
             } // and if zero, just do nothing; don't need to validate tail etc

--- a/src/Channels/WritableBuffer.cs
+++ b/src/Channels/WritableBuffer.cs
@@ -163,19 +163,25 @@ namespace Channels
 
         public void CommitBytes(int bytesWritten)
         {
-            Debug.Assert(_tail != null);
-            Debug.Assert(!_tail.ReadOnly);
-            Debug.Assert(_tail.Block != null);
-            Debug.Assert(_tail.Next == null);
-            Debug.Assert(_tail.End == _tailIndex);
+            if (bytesWritten > 0)
+            {
+                Debug.Assert(_tail != null);
+                Debug.Assert(!_tail.ReadOnly);
+                Debug.Assert(_tail.Block != null);
+                Debug.Assert(_tail.Next == null);
+                Debug.Assert(_tail.End == _tailIndex);
 
-            var block = _tail.Block;
-            var blockIndex = _tailIndex + bytesWritten;
+                var block = _tail.Block;
+                var blockIndex = _tailIndex + bytesWritten;
 
-            Debug.Assert(blockIndex <= block.Data.Length);
+                Debug.Assert(blockIndex <= block.Data.Length);
 
-            _tail.End = blockIndex;
-            _tailIndex = blockIndex;
+                _tail.End = blockIndex;
+                _tailIndex = blockIndex;
+            } else if (bytesWritten < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bytesWritten));
+            } // and if zero, just do nothing; don't need to validate tail etc
         }
     }
 }

--- a/test/Channels.Tests/WritableBufferFacts.cs
+++ b/test/Channels.Tests/WritableBufferFacts.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Channels.Tests
+{
+    public class WritableBufferFacts
+    {
+        [Fact]
+        public async Task CanWriteNothingToBuffer()
+        {
+            using (var memoryPool = new MemoryPool())
+            {
+                var channel = new Channel(memoryPool);
+                var buffer = channel.Alloc();
+                buffer.CommitBytes(0); // doing nothing, the hard way
+                await buffer.FlushAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
in `CommitBytes`, if we're committing zero, it is possible that `Ensure` has never been called, so none of our assertions (or consequences) apply
