### PR TITLE
Experimental TransportProvider API - provides abstraction  over underlying transports

### DIFF
--- a/src/Channels.Networking.Libuv/UvTcpListener.cs
+++ b/src/Channels.Networking.Libuv/UvTcpListener.cs
@@ -4,7 +4,7 @@ using Channels.Networking.Libuv.Interop;
 
 namespace Channels.Networking.Libuv
 {
-    public class UvTcpListener
+    public class UvTcpListener : IDisposable
     {
         private static Action<UvStreamHandle, int, Exception, object> _onConnectionCallback = OnConnectionCallback;
         private static Action<object> _startListeningCallback = state => ((UvTcpListener)state).Listen();
@@ -39,7 +39,8 @@ namespace Channels.Networking.Libuv
             _thread.Post(_stopListeningCallback, this);
         }
 
-        private void Dispose()
+        // review: should this also stop?
+        public void Dispose()
         {
             _listenSocket.Dispose();
         }

--- a/src/Channels.Networking.Libuv/UvTcpTransportProvider.cs
+++ b/src/Channels.Networking.Libuv/UvTcpTransportProvider.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Channels.Networking.Libuv
+{
+    /// <summary>
+    /// A TransportProvider using libuv
+    /// </summary>
+    public class UvTcpTransportProvider : TransportProvider
+    {
+        UvThread thread = new UvThread();
+        /// <summary>
+        /// Open a client connection to the designated resource
+        /// </summary>
+        public async override Task<IChannel> ConnectAsync(string configuration)
+        {
+            var endpoint = await ParseIPEndPoint(configuration);
+            return await new UvTcpClient(thread, endpoint).ConnectAsync();
+        }
+
+        /// <summary>
+        /// Create a server instance listening to the designated resource
+        /// </summary>
+        public override async Task<IDisposable> StartServerAsync(string configuration, Action<IChannel> callback)
+        {
+            var endpoint = await ParseIPEndPoint(configuration);
+            var server = new UvTcpListener(thread, endpoint);
+            server.OnConnection(callback);
+            server.Start();
+            return server;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                thread?.Dispose();
+                thread = null;
+            }
+        }
+    }
+}

--- a/src/Channels.Networking.Sockets/SocketConnection.cs
+++ b/src/Channels.Networking.Sockets/SocketConnection.cs
@@ -109,6 +109,10 @@ namespace Channels.Networking.Sockets
         {
             if (disposing)
             {
+                _input?.CompleteReading();
+                _input = null;
+                _output?.CompleteWriting();
+                _output = null;
                 GC.SuppressFinalize(this);
                 _socket?.Dispose();
                 _socket = null;
@@ -214,7 +218,11 @@ namespace Channels.Networking.Sockets
                     {
                         if (!flushed)
                         {
-                            await buffer.FlushAsync();
+                            try
+                            {
+                                await buffer.FlushAsync();
+                            }
+                            catch { }
                         }
                     }
                 }

--- a/src/Channels.Networking.Sockets/SocketTransportProvider.cs
+++ b/src/Channels.Networking.Sockets/SocketTransportProvider.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Channels.Networking.Sockets
+{
+    /// <summary>
+    /// A TransportProvider using managed sockets (System.Net.Sockets.Socket)
+    /// </summary>
+    public class SocketTransportProvider : TransportProvider
+    {
+        /// <summary>
+        /// Open a client connection to the designated resource
+        /// </summary>
+        public async override Task<IChannel> ConnectAsync(string configuration)
+        {
+            var endpoint = await ParseIPEndPoint(configuration);
+            return await SocketConnection.ConnectAsync(endpoint, ChannelFactory);
+        }
+        /// <summary>
+        /// Create a server instance listening to the designated resource
+        /// </summary>
+        public override async Task<IDisposable> StartServerAsync(string configuration, Action<IChannel> callback)
+        {
+            var endpoint = await ParseIPEndPoint(configuration);
+            var server = new SocketListener(ChannelFactory);
+            server.OnConnection(callback);
+            server.Start(endpoint);
+            return server;
+        }
+    }
+}

--- a/src/Channels/Networking/DirectTransportProvider.cs
+++ b/src/Channels/Networking/DirectTransportProvider.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections;
+using System.Threading.Tasks;
+
+namespace Channels.Networking
+{
+    /// <summary>
+    /// A direct transport that connects a client and server without going through any networking layer
+    /// </summary>
+    public class DirectTransportProvider : TransportProvider
+    {
+        private Hashtable servers = new Hashtable();
+
+        /// <summary>
+        /// Open a client connection to the designated resource
+        /// </summary>
+        public override Task<IChannel> ConnectAsync(string configuration)
+        {
+            if (configuration == null) configuration = "";
+            var server = (DirectTransportServer)servers[configuration];
+            if (server == null) throw new InvalidOperationException($"No server listening for: '{configuration}'");
+
+            return Task.FromResult(server.AddClient());
+        }
+        /// <summary>
+        /// Create a server instance listening to the designated resource
+        /// </summary>
+        public override Task<IDisposable> StartServerAsync(string configuration, Action<IChannel> callback)
+        {
+            DirectTransportServer server;
+            lock (servers) // planning to mutate, so lock
+            {
+                server = (DirectTransportServer)servers[configuration];
+                if (server != null) throw new InvalidOperationException($"Server already listening for: '{configuration}'");
+
+                server = new DirectTransportServer(this, configuration, callback);
+                servers[configuration] = server;
+            }
+            return Task.FromResult<IDisposable>(server);
+        }
+        private void Remove(string key)
+        {
+            lock (servers) // planning to mutate, so lock
+            {
+                servers.Remove(key);
+            }
+        }
+
+        private class DirectTransportServer : IDisposable
+        {
+            private Action<IChannel> callback;
+            private string key;
+            private DirectTransportProvider provider;
+
+            public DirectTransportServer(DirectTransportProvider provider, string  key, Action<IChannel> callback)
+            {
+                this.provider = provider;
+                this.key = key;
+                this.callback = callback;
+            }
+
+            public void Dispose()
+            {
+                provider.Remove(key);
+                provider = null;
+                key = null;
+            }
+
+            internal IChannel AddClient()
+            {
+                var clientToServer = provider.CreateChannel();
+                var serverToClient = provider.CreateChannel();
+
+                var client = new DirectChannel(serverToClient, clientToServer);
+                var server = new DirectChannel(clientToServer, serverToClient);
+                callback(server);
+                return client;
+            }
+            private class DirectChannel : IChannel
+            {
+                IReadableChannel input;
+                IWritableChannel output;
+
+                public DirectChannel(IReadableChannel input, IWritableChannel output)
+                {
+                    this.input = input;
+                    this.output = output;
+                }
+                public IReadableChannel Input => input;
+
+                public IWritableChannel Output => output;
+
+                public void Dispose() { }
+            }
+        }
+
+        private Channel CreateChannel() => ChannelFactory.CreateChannel();
+
+        /// <summary>
+        /// Releases all resources owned by this object
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if(disposing)
+            {
+                foreach (DirectTransportServer server in servers)
+                {
+                    server?.Dispose();
+                    servers = null;
+                }
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Channels/Networking/TransportProvider.cs
+++ b/src/Channels/Networking/TransportProvider.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Globalization;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Channels.Networking
+{
+    /// <summary>
+    /// Represents a transport that is able to establish connections from client to server,
+    /// or to start a listener to operate as a server
+    /// </summary>
+    public abstract class TransportProvider : IDisposable
+    {
+        private ChannelFactory channelFactory;
+
+        /// <summary>
+        /// Provides access to the channel factory for this provider
+        /// </summary>
+        /// <remarks>This factory is lazily instantiated</remarks>
+        protected ChannelFactory ChannelFactory => channelFactory ?? (channelFactory = new ChannelFactory());
+
+        /// <summary>
+        /// Open a client connection to the designated resource
+        /// </summary>
+        public abstract Task<IChannel> ConnectAsync(string configuration);
+        /// <summary>
+        /// Create a server instance listening to the designated resource
+        /// </summary>
+        public abstract Task<IDisposable> StartServerAsync(string configuration, Action<IChannel> callback);
+
+        /// <summary>
+        /// Releases all resources owned by this object
+        /// </summary>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Releases all resources owned by this object
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if(disposing)
+            {
+                channelFactory?.Dispose();
+                channelFactory = null;
+            }
+        }
+
+        /// <summary>
+        /// Parse the configuration as an IPEndPoint
+        /// </summary>
+        public static ValueTask<IPEndPoint> ParseIPEndPoint(string configuration, int defaultPort = -1)
+        {
+            if (string.IsNullOrWhiteSpace(configuration)) throw new ArgumentException(nameof(configuration));
+            configuration = configuration.Trim();
+
+            // try IP by itself first; this is necessary to help distinguish between IPv6 without port which looks
+            // confusingly similar to IPv4:port
+            IPAddress addr;
+            if (!configuration.Contains("]:") && IPAddress.TryParse(configuration, out addr))
+            {
+                if (defaultPort < 0)
+                {
+                    throw new ArgumentException($"No port specified", nameof(configuration));
+                }
+                return new ValueTask<IPEndPoint>(new IPEndPoint(addr, defaultPort));
+            }
+
+            // try to resolve a *:port
+            int port;
+            int colonIndex = configuration.LastIndexOf(':');
+            string endpointString = colonIndex < 0 ? configuration.Trim() : configuration.Substring(0, colonIndex).Trim(),
+                portString = colonIndex < 0 ? "" : configuration.Substring(colonIndex + 1).Trim();
+
+            if (string.IsNullOrWhiteSpace(portString))
+            {
+                if (defaultPort < 0)
+                {
+                    throw new ArgumentException($"No port specified", nameof(configuration));
+                }
+                port = defaultPort;
+            }
+            else
+            {
+                if (!int.TryParse(portString, NumberStyles.Integer, CultureInfo.InvariantCulture, out port))
+                {
+                    throw new ArgumentException($"Cannot parse port '{portString}'", nameof(configuration));
+                }
+            }
+
+            // is the remainder on the left an IP address?
+            if(IPAddress.TryParse(endpointString, out addr))
+            {
+                return new ValueTask<IPEndPoint>(new IPEndPoint(addr, port));
+            }
+
+            // otherwise, use DNS lookup
+            return new ValueTask<IPEndPoint>(ResolveDnsAndCreateIPEndPoint(endpointString, port));
+        }
+
+        private static async Task<IPEndPoint> ResolveDnsAndCreateIPEndPoint(string endpoint, int port)
+        {
+            var addresses = await Dns.GetHostAddressesAsync(endpoint);
+            if(addresses.Length == 0)
+            {
+                throw new InvalidOperationException($"Unable to resolve endpoint: '{endpoint}'");
+            }
+            return new IPEndPoint(addresses[0], port);
+        }
+    }
+}

--- a/src/Channels/project.json
+++ b/src/Channels/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "0.2.0-beta-*",
   "description": "An abstraction for doing efficient asynchronous IO",
   "packOptions": {
@@ -20,6 +20,11 @@
 
   "frameworks": {
     "net451": {},
-    "netstandard1.3": {}
+    "netstandard1.3": {
+      "dependencies": {
+        "System.Collections.NonGeneric": "4.0.1",
+        "System.Net.NameResolution": "4.0.0"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR is intended as a discussion piece; any code is intended to be illustrative only.

Design goals:
- abstract both client and server from the concrete implementations
- take into account that some applications need to create additional servers and clients at runtime; it may not be sufficient to pass in just an `IChannel` (example: redis cluster node changes)
- consider that the endpoint address is contextual; use `string` to allow flexibility, but provide base implementation that supports IP and DNS addressing (as common cases)
- provide support for in-process direct routing between a logical "client" and "server", which would work identically
- provide a mechanism to encapsulate the common state that is wider than an individual connection or listener - `UvThread`, `ChannelFactory`, etc
- potentially allow injection; for example, an `SslTransportProvider` could take a downstream provider and do all the handshakes in the `async` portion before exposing the (wrapped - ssl etc) `IChannel` to the listener or caller
- provide an API surface that will allow provider-specific configuration (so in the `SslTransportProvider` example, the provider would be where certificates and protocols are configured)

---

Note: I have tweaked some of the tests to use this new API; obviously in a real scenario the samples (`HttpServer,`, `HttpClient` etc) would also use this approach, i.e. passing in a transport-provider instead of having `StartAcceptingLibuvConnections()`, `StartAcceptingRIOConnections()`, etc.

---

Proposed implementation:
- an `abstract TransportProvider` base type
- `Task<IChannel> ConnectAsync(string configuration)` allows connection as a client
- `Task<IDisposable> StartServerAsync(string configuration, Action<IChannel> callback)` allows creation of a listener, with the familiar "what to do with new connections" callback
- concrete implementations override these `abstract` methods to provide implementation-specific code
- any additional state (`UvThread` etc) can be held against the provider, which is `IDisposable` for clean-up
- the base type provides lazy access to a reusable `ChannelFactory` if required

Typical usage as a client:

```
using(var client = await provider.ConnectAsync(endpoint))
{
     // do stuff
}
```

Typical usage as a server:

```
_server = await provider.StartServerAsync(endpoint, OnAccepted); // disposed via Dispose()
```

The provider here would presumably be injected via the constructor. For example:

```
using(var libuv = new LibuvTransportProvider()) // wraps thread and provides abstraction API
using(var webSocketServer = new WebSocketServer(libuv))
{
     await webSocketServer.StartAcceptingConnections("127.0.0.1");
     Console.WriteLine("Server running; press any key to exit");
     Console.ReadKey(); 
}
```

---

For direct connections, `DirectTransportProvider` provides an API to expose artificial servers and allow connections:

```
using(var direct = new DirectTransportProvider())
{
    using(var server = new WebSocketServer(direct))
    {
        // start running a logical server; note: supports server routing via key here
        await webSocketServer.StartAcceptingConnections("abc");

        // create a client that talks to that server
        using(var client = await WebSocketServer.ConnectAsync(direct, "abc"))
        {
            // do stuff here!
        }
    }
}
```

(yak shaving: in this case, could also be `StartAcceptingConnections(direct, "abc")`; that's not a key point though)

---

So; thoughts?
