### PR TITLE
Added test to show race condition, showing a consumer bytes that are not flushed

### DIFF
--- a/test/Channels.Tests/ChannelFacts.cs
+++ b/test/Channels.Tests/ChannelFacts.cs
@@ -12,6 +12,28 @@ namespace Channels.Tests
     public class ChannelFacts
     {
         [Fact]
+        public async Task ReaderShouldntGetUnflushedBytes()
+        {
+            using (var cf = new ChannelFactory())
+            {
+                var c = cf.CreateChannel();
+                var buffer = c.Alloc(4);
+                buffer.Ensure(4);
+                buffer.Memory.Write<int>(10);
+                buffer.CommitBytes(4);
+                await buffer.FlushAsync();
+                buffer = c.Alloc(4);
+                buffer.Ensure(4);
+                buffer.Memory.Write<int>(10);
+                buffer.CommitBytes(4);
+
+                var reader = await c.ReadAsync();
+
+                Assert.Equal(4,reader.Length);
+            }
+        }
+
+        [Fact]
         public async Task WritingDataMakesDataReadableViaChannel()
         {
             using (var cf = new ChannelFactory())


### PR DESCRIPTION
Sorry, but repo got messed up, @mgravell has a PR for the same functionality. Now this is a test to show #88 
