### PR TITLE
Add new Reserve API that alows data to be populated after the fact

### DIFF
--- a/src/Channels/BufferSegment.cs
+++ b/src/Channels/BufferSegment.cs
@@ -55,12 +55,12 @@ namespace Channels
         }
 
         // Cloning ctor
-        private BufferSegment(IBuffer buffer, int start, int end)
+        internal BufferSegment(IBuffer buffer, int start, int end, bool readOnly = true)
         {
             Buffer = buffer;
             Start = start;
             End = end;
-            ReadOnly = true;
+            ReadOnly = readOnly;
 
             Buffer = Buffer.Preserve(start, end - start);
         }

--- a/src/Channels/Memory.cs
+++ b/src/Channels/Memory.cs
@@ -98,6 +98,41 @@ namespace Channels
             return new Memory<T>(_array, _offset + offset, length, _memory != null);
         }
 
+        /// <summary>
+        /// Determines whether the current span is a slice of the supplied span
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe bool IsSliceOf(Memory<T> parentSpan)
+        {
+            var elementSize = Unsafe.SizeOf<T>();
+
+            // if this instance is array-based, they must both be; parent must encapsulate the child (current instance)
+            if (_array != null || parentSpan._array != null)
+            {
+                return (object)parentSpan._array == (object)_array
+                    && parentSpan._offset <= _offset
+                    && (parentSpan._offset + parentSpan._memoryLength) >= (_offset + _memoryLength);
+            }
+
+            // otherwise, pointers:
+            byte* thisStart = (byte*)UnsafePointer, parentStart = (byte*)parentSpan.UnsafePointer;
+
+            return parentStart <= thisStart // check lower limit
+                && ((thisStart - parentStart) % Unsafe.SizeOf<T>()) == 0 // check alignment
+                && (parentStart + (parentSpan._memoryLength * Unsafe.SizeOf<T>()))
+                >= (thisStart + (_memoryLength * Unsafe.SizeOf<T>())); // check upper limit
+        }
+
+        /// <summary>
+        /// Determines whether the current span is a slice of the supplied span
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsSliceOf(Memory<T> parentSpan, out int start)
+        {
+            start = _offset - parentSpan._offset;
+            return IsSliceOf(parentSpan);
+        }
+
         public bool TryGetArray(out ArraySegment<T> buffer)
         {
             if (_array == null)

--- a/src/Channels/WritableBuffer.cs
+++ b/src/Channels/WritableBuffer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Channels
@@ -94,5 +95,27 @@ namespace Channels
         {
             return _channel.FlushAsync();
         }
+
+        /// <summary>
+        /// Writes past a block of output data, allowing the caller to supply this
+        /// value at a later point. This is in particular useful for writing
+        /// length-prefix values after the actual data has been written.
+        /// </summary>
+        public Memory<byte> Reserve(int length)
+            => _channel.Reserve(length);
+
+        /// <summary>
+        /// Writes past a block of output data, allowing the caller to supply this
+        /// value at a later point. This is in particular useful for writing
+        /// length-prefix values after the actual data has been written.
+        /// </summary>
+        public Memory<byte> Reserve<[Primitive]T>() where T : struct
+            => _channel.Reserve(Unsafe.SizeOf<T>());
+
+        /// <summary>
+        /// Resolve the previously taken reservation, and remove any unused bytes from the
+        /// </summary>
+        public void Truncate(Memory<byte> reservation, int length)
+            => _channel.Truncate(reservation, length);
     }
 }

--- a/test/Channels.Tests/MemoryFacts.cs
+++ b/test/Channels.Tests/MemoryFacts.cs
@@ -96,5 +96,161 @@ namespace Channels.Tests
                 }
             }
         }
+
+        [Fact]
+        public unsafe void IsSliceOf_PointerVersusArraySpansNeverMatch()
+        {
+            ulong[] data = new ulong[8];
+            fixed (ulong* ptr = data)
+            {
+                Memory<ulong> arrayBased = new Memory<ulong>(data, 0, data.Length);
+                Memory<ulong> pointerBased = new Memory<ulong>(ptr, 0, 8);
+
+                // comparing array to pointer says "no"
+                Assert.False(arrayBased.IsSliceOf(pointerBased));
+                Assert.False(pointerBased.IsSliceOf(arrayBased));
+
+                // comparing to self says yes
+                Assert.True(arrayBased.IsSliceOf(arrayBased));
+                Assert.True(pointerBased.IsSliceOf(pointerBased));
+
+            }
+        }
+
+        [Fact]
+        public unsafe void IsSliceOf_NonOverlappingSpansNeverMatch()
+        {
+            ulong[] data = new ulong[8];
+            fixed (ulong* ptr = data)
+            {
+                Memory<ulong> arrayBased = new Memory<ulong>(data, 0, data.Length);
+                var x = arrayBased.Slice(1, 2);
+                var y = arrayBased.Slice(5, 2);
+                Assert.False(x.IsSliceOf(y));
+                Assert.False(y.IsSliceOf(x));
+
+                Memory<ulong> pointerBased = new Memory<ulong>(ptr, 0, 8);
+                x = pointerBased.Slice(1, 2);
+                y = pointerBased.Slice(5, 2);
+                Assert.False(x.IsSliceOf(y));
+                Assert.False(y.IsSliceOf(x));
+            }
+        }
+
+        [Fact]
+        public unsafe void IsSliceOf_PartialOverlappingSpansNeverMatch()
+        {
+            ulong[] data = new ulong[8];
+            fixed (ulong* ptr = data)
+            {
+                Memory<ulong> arrayBased = new Memory<ulong>(data, 0, data.Length);
+                var x = arrayBased.Slice(1, 4);
+                var y = arrayBased.Slice(3, 4);
+                Assert.False(x.IsSliceOf(y));
+                Assert.False(y.IsSliceOf(x));
+
+                Memory<ulong> pointerBased = new Memory<ulong>(ptr, 0, 8);
+                x = pointerBased.Slice(1, 4);
+                y = pointerBased.Slice(3, 4);
+                Assert.False(x.IsSliceOf(y));
+                Assert.False(y.IsSliceOf(x));
+            }
+        }
+
+        [Fact]
+        public unsafe void IsSliceOf_EqualSpansAlwaysMatch()
+        {
+            ulong[] data = new ulong[8];
+            fixed (ulong* ptr = data)
+            {
+                Memory<ulong> arrayBased = new Memory<ulong>(data, 0, data.Length);
+                Assert.True(arrayBased.IsSliceOf(arrayBased));
+                for (int start = 0; start < 8; start++)
+                {
+                    for (int length = data.Length - start; length >= 0; length--)
+                    {
+                        Assert.True(arrayBased.Slice(start, length).IsSliceOf(arrayBased.Slice(start, length)));
+                    }
+                }
+
+                Memory<ulong> pointerBased = new Memory<ulong>(ptr, 0, 8);
+                Assert.True(pointerBased.IsSliceOf(pointerBased));
+                for (int start = 0; start < 8; start++)
+                {
+                    for (int length = data.Length - start; length >= 0; length--)
+                    {
+                        Assert.True(pointerBased.Slice(start, length).IsSliceOf(pointerBased.Slice(start, length)));
+                    }
+                }
+            }
+        }
+        [Fact]
+        public void IsSliceOf_SubSpansShouldMatch_BasicArrays()
+        {
+            int[] data = new int[20];
+
+            var outer = new Memory<int>(data, 0, 20);
+            var inner = outer.Slice(6, 3);
+
+            Assert.True(outer.IsSliceOf(outer));
+            Assert.True(inner.IsSliceOf(inner));
+
+            Assert.False(outer.IsSliceOf(inner));
+            Assert.True(inner.IsSliceOf(outer));
+            int start;
+            Assert.True(inner.IsSliceOf(outer, out start));
+            Assert.Equal(6, start);
+
+
+            var innerInner = inner.Slice(1, inner.Length - 1);
+            Assert.True(innerInner.IsSliceOf(innerInner));
+            Assert.True(innerInner.IsSliceOf(inner));
+            Assert.True(innerInner.IsSliceOf(inner, out start));
+            Assert.Equal(1, start);
+            Assert.True(innerInner.IsSliceOf(outer));
+            Assert.True(innerInner.IsSliceOf(outer, out start));
+            Assert.Equal(7, start);
+        }
+
+        [Fact]
+        public unsafe void IsSliceOf_SubSpansShouldMatch_BasicPointers()
+        {
+            int* data = stackalloc int[20];
+
+            var outer = new Memory<int>(data, 0, 20);
+            var inner = outer.Slice(6, 3);
+
+            Assert.True(outer.IsSliceOf(outer));
+            Assert.True(inner.IsSliceOf(inner));
+
+            Assert.False(outer.IsSliceOf(inner));
+            Assert.True(inner.IsSliceOf(outer));
+            int start;
+            Assert.True(inner.IsSliceOf(outer, out start));
+            Assert.Equal(6, start);
+
+
+            var innerInner = inner.Slice(1, inner.Length - 1);
+            Assert.True(innerInner.IsSliceOf(innerInner));
+            Assert.True(innerInner.IsSliceOf(inner));
+            Assert.True(innerInner.IsSliceOf(inner, out start));
+            Assert.Equal(1, start);
+            Assert.True(innerInner.IsSliceOf(outer));
+            Assert.True(innerInner.IsSliceOf(outer, out start));
+            Assert.Equal(7, start);
+        }
+
+
+        [Fact]
+        public unsafe void IsSliceOf_MisalignedPointersShouldNotMatch()
+        {
+            byte* data = stackalloc byte[10 * sizeof(ulong)];
+            var outer = new Memory<ulong>(data, 0, 10);
+            var inner = new Memory<ulong>(data + 8, 0, 1);
+            Assert.True(inner.IsSliceOf(outer));
+
+            inner = new Memory<ulong>(data + 11, 0, 1);
+            Assert.False(inner.IsSliceOf(outer));
+        }
     }
 }


### PR DESCRIPTION
Note: overhauled; now does everything just by handing the caller a `Span<T>`
