### PR TITLE
Move Consumed back to IReadableChannel as Advance

### DIFF
--- a/samples/Channels.Samples/HttpClient/ChannelHttpContent.cs
+++ b/samples/Channels.Samples/HttpClient/ChannelHttpContent.cs
@@ -62,7 +62,7 @@ namespace Channels.Samples
                 }
                 finally
                 {
-                    inputBuffer.Consumed(consumed);
+                    _output.Advance(consumed);
                 }
             }
         }

--- a/samples/Channels.Samples/HttpClient/LibuvHttpClientHandler.cs
+++ b/samples/Channels.Samples/HttpClient/LibuvHttpClientHandler.cs
@@ -219,7 +219,7 @@ namespace Channels.Samples
                 }
                 finally
                 {
-                    responseBuffer.Consumed(consumed);
+                    connection.Input.Advance(consumed);
                 }
 
                 if (needMoreData)

--- a/samples/Channels.Samples/HttpServer/HttpConnection.cs
+++ b/samples/Channels.Samples/HttpServer/HttpConnection.cs
@@ -108,7 +108,7 @@ namespace Channels.Samples.Http
                 }
                 finally
                 {
-                    buffer.Consumed(buffer.Start, buffer.End);
+                    _input.Advance(buffer.Start, buffer.End);
                 }
 
                 var context = _application.CreateContext(this);

--- a/samples/Channels.Samples/IO/Compression/CompressionChannelFactoryExtensions.cs
+++ b/samples/Channels.Samples/IO/Compression/CompressionChannelFactoryExtensions.cs
@@ -79,7 +79,7 @@ namespace Channels.Samples.IO.Compression
 
                     inputBuffer = inputBuffer.Slice(0, consumed);
 
-                    inputBuffer.Consumed();
+                    input.Advance(inputBuffer.End);
 
                     await writerBuffer.FlushAsync();
                 }
@@ -164,7 +164,7 @@ namespace Channels.Samples.IO.Compression
                         }
                     }
 
-                    inputBuffer.Consumed();
+                    input.Advance(inputBuffer.End);
 
                     await writerBuffer.FlushAsync();
                 }

--- a/samples/Channels.Samples/RawLibuvHttpClientSample.cs
+++ b/samples/Channels.Samples/RawLibuvHttpClientSample.cs
@@ -55,7 +55,7 @@ namespace Channels.Samples
                 }
                 finally
                 {
-                    inputBuffer.Consumed();
+                    input.Advance(inputBuffer.End);
                 }
 
                 var awaiter = input.ReadAsync();

--- a/samples/Channels.Samples/RawLibuvHttpServerSample.cs
+++ b/samples/Channels.Samples/RawLibuvHttpServerSample.cs
@@ -74,7 +74,7 @@ namespace Channels.Samples
                         finally
                         {
                             // Consume the input
-                            input.Consumed(input.Start, input.End);
+                            connection.Input.Advance(input.Start, input.End);
                         }
                     }
                 }

--- a/src/Channels.Networking.Libuv/UvTcpConnection.cs
+++ b/src/Channels.Networking.Libuv/UvTcpConnection.cs
@@ -77,7 +77,7 @@ namespace Channels.Networking.Libuv
                     }
                     finally
                     {
-                        buffer.Consumed();
+                        _output.Advance(buffer.End);
                     }
                 }
             }

--- a/src/Channels.Networking.Sockets/SocketConnection.cs
+++ b/src/Channels.Networking.Sockets/SocketConnection.cs
@@ -283,7 +283,7 @@ namespace Channels.Networking.Sockets
                     }
                     finally
                     {
-                        buffer.Consumed();
+                        _output.Advance(buffer.End);
                     }
                 }
                 _output.CompleteReader();

--- a/src/Channels.Networking.Windows.RIO/RioTcpConnection.cs
+++ b/src/Channels.Networking.Windows.RIO/RioTcpConnection.cs
@@ -103,7 +103,7 @@ namespace Channels.Networking.Windows.RIO
                     await SendAsync(current, endOfMessage: true);
                 }
 
-                buffer.Consumed();
+                _output.Advance(buffer.End);
             }
 
             _output.CompleteReader();

--- a/src/Channels/Channel.cs
+++ b/src/Channels/Channel.cs
@@ -322,12 +322,7 @@ namespace Channels
             return new ReadableBuffer(new ReadCursor(_head), new ReadCursor(_tail, _tail?.End ?? 0));
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="consumed"></param>
-        /// <param name="examined"></param>
-        public void Advance(ReadCursor consumed, ReadCursor examined)
+        void IReadableChannel.Advance(ReadCursor consumed, ReadCursor examined)
         {
             PooledBufferSegment returnStart = null;
             PooledBufferSegment returnEnd = null;

--- a/src/Channels/Channel.cs
+++ b/src/Channels/Channel.cs
@@ -285,7 +285,7 @@ namespace Channels
                 return new ReadableBuffer(); // empty
             }
 
-            return new ReadableBuffer(null, new ReadCursor(_writingHead, _writingHeadIndex), new ReadCursor(_writingTail, _writingTailIndex), isOwner: false);
+            return new ReadableBuffer(new ReadCursor(_writingHead, _writingHeadIndex), new ReadCursor(_writingTail, _writingTailIndex), isOwner: false);
         }
 
         private Task CompleteWriteAsync()
@@ -319,17 +319,15 @@ namespace Channels
                 throw new InvalidOperationException("Already consuming.");
             }
 
-            return new ReadableBuffer(this, new ReadCursor(_head), new ReadCursor(_tail, _tail?.End ?? 0));
+            return new ReadableBuffer(new ReadCursor(_head), new ReadCursor(_tail, _tail?.End ?? 0));
         }
 
-        internal void EndRead(ReadCursor end)
-        {
-            EndRead(end, end);
-        }
-
-        internal void EndRead(
-            ReadCursor consumed,
-            ReadCursor examined)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="consumed"></param>
+        /// <param name="examined"></param>
+        public void Advance(ReadCursor consumed, ReadCursor examined)
         {
             PooledBufferSegment returnStart = null;
             PooledBufferSegment returnEnd = null;

--- a/src/Channels/Channel.cs
+++ b/src/Channels/Channel.cs
@@ -322,7 +322,9 @@ namespace Channels
             return new ReadableBuffer(new ReadCursor(_head), new ReadCursor(_tail, _tail?.End ?? 0));
         }
 
-        void IReadableChannel.Advance(ReadCursor consumed, ReadCursor examined)
+        void IReadableChannel.Advance(ReadCursor consumed, ReadCursor examined) => AdvanceReader(consumed, examined);
+
+        public void AdvanceReader(ReadCursor consumed, ReadCursor examined)
         {
             PooledBufferSegment returnStart = null;
             PooledBufferSegment returnEnd = null;

--- a/src/Channels/ChannelExtensions.cs
+++ b/src/Channels/ChannelExtensions.cs
@@ -29,6 +29,11 @@ namespace Channels
 
     public static class ReadableChannelExtensions
     {
+        public static void Advance(this IReadableChannel input, ReadCursor cursor)
+        {
+            input.Advance(cursor, cursor);
+        }
+
         public static ValueTask<int> ReadAsync(this IReadableChannel input, Span<byte> destination)
         {
             while (true)
@@ -46,7 +51,7 @@ namespace Channels
                 var sliced = inputBuffer.Slice(0, destination.Length);
                 sliced.CopyTo(destination);
                 int actual = sliced.Length;
-                inputBuffer.Consumed(sliced.End);
+                input.Advance(sliced.End);
 
                 if (actual != 0)
                 {
@@ -100,7 +105,7 @@ namespace Channels
                 }
                 finally
                 {
-                    inputBuffer.Consumed();
+                    input.Advance(inputBuffer.End);
                 }
             }
         }
@@ -128,7 +133,7 @@ namespace Channels
                 }
                 finally
                 {
-                    inputBuffer.Consumed();
+                    input.Advance(inputBuffer.End);
                 }
             }
         }
@@ -144,7 +149,7 @@ namespace Channels
                 var sliced = inputBuffer.Slice(0, destination.Length);
                 sliced.CopyTo(destination);
                 int actual = sliced.Length;
-                inputBuffer.Consumed(sliced.End);
+                input.Advance(sliced.End);
 
                 if (actual != 0)
                 {

--- a/src/Channels/IReadableChannel.cs
+++ b/src/Channels/IReadableChannel.cs
@@ -21,10 +21,14 @@ namespace Channels
         Task Reading { get; }
 
         /// <summary>
-        /// Moves the channel forward
+        /// Moves forward the channels read cursor to after the consumed data.
         /// </summary>
-        /// <param name="consumed"></param>
-        /// <param name="examined"></param>
+        /// <param name="consumed">Marks the extent of the data that has been succesfully proceesed.</param>
+        /// <param name="examined">Marks the extent of the data that has been read and examined.</param>
+        /// <remarks>
+        /// The memory for the consumed data will be released and no longer available. 
+        /// The examined data communicates to the channel when it should signal more data is available.
+        /// </remarks>
         void Advance(ReadCursor consumed, ReadCursor examined);
 
         /// <summary>

--- a/src/Channels/IReadableChannel.cs
+++ b/src/Channels/IReadableChannel.cs
@@ -21,6 +21,13 @@ namespace Channels
         Task Reading { get; }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="consumed"></param>
+        /// <param name="examined"></param>
+        void Advance(ReadCursor consumed, ReadCursor examined);
+
+        /// <summary>
         /// Signal to the producer that the consumer is done reading.
         /// </summary>
         /// <param name="exception">Optional Exception indicating a failure that's causing the channel to complete.</param>

--- a/src/Channels/IReadableChannel.cs
+++ b/src/Channels/IReadableChannel.cs
@@ -21,7 +21,7 @@ namespace Channels
         Task Reading { get; }
 
         /// <summary>
-        /// 
+        /// Moves the channel forward
         /// </summary>
         /// <param name="consumed"></param>
         /// <param name="examined"></param>

--- a/src/Channels/ReadableBuffer.cs
+++ b/src/Channels/ReadableBuffer.cs
@@ -18,7 +18,6 @@ namespace Channels
 
         private readonly PooledBufferSpan _span;
         private readonly bool _isOwner;
-        private readonly Channel _channel;
 
         private ReadCursor _start;
         private ReadCursor _end;
@@ -54,15 +53,14 @@ namespace Channels
         /// </summary>
         public ReadCursor End => _end;
 
-        internal ReadableBuffer(Channel channel, ReadCursor start, ReadCursor end) :
-            this(channel, start, end, isOwner: false)
+        internal ReadableBuffer(ReadCursor start, ReadCursor end) :
+            this(start, end, isOwner: false)
         {
 
         }
 
-        internal ReadableBuffer(Channel channel, ReadCursor start, ReadCursor end, bool isOwner)
+        internal ReadableBuffer(ReadCursor start, ReadCursor end, bool isOwner)
         {
-            _channel = channel;
             _start = start;
             _end = end;
             _isOwner = isOwner;
@@ -74,8 +72,6 @@ namespace Channels
 
         private ReadableBuffer(ref ReadableBuffer buffer)
         {
-            _channel = buffer._channel;
-
             var begin = buffer._start;
             var end = buffer._end;
 
@@ -264,7 +260,7 @@ namespace Channels
         /// <param name="end">The ending (inclusive) <see cref="ReadCursor"/> of the slice</param>
         public ReadableBuffer Slice(ReadCursor start, ReadCursor end)
         {
-            return new ReadableBuffer(_channel, start, end);
+            return new ReadableBuffer(start, end);
         }
 
         /// <summary>
@@ -283,7 +279,7 @@ namespace Channels
         /// <param name="start">The starting (inclusive) <see cref="ReadCursor"/> at which to begin this slice.</param>
         public ReadableBuffer Slice(ReadCursor start)
         {
-            return new ReadableBuffer(_channel, start, _end);
+            return new ReadableBuffer(start, _end);
         }
 
         /// <summary>
@@ -294,7 +290,7 @@ namespace Channels
         {
             if (start == 0) return this;
 
-            return new ReadableBuffer(_channel, _start.Seek(start), _end);
+            return new ReadableBuffer(_start.Seek(start), _end);
         }
 
         /// <summary>
@@ -386,44 +382,6 @@ namespace Channels
 
             _start = default(ReadCursor);
             _end = default(ReadCursor);
-        }
-
-        private void ThrowIfNotConsumable()
-        {
-            if (_channel == null)
-            {
-                throw new InvalidOperationException("This data is not from a read operation and cannot be consumed");
-            }
-        }
-
-        /// <summary>
-        /// Mark the entire <see cref="ReadableBuffer"/> as consumed.
-        /// </summary>
-        public void Consumed()
-        {
-            ThrowIfNotConsumable();
-            _channel.EndRead(End, End);
-        }
-
-        /// <summary>
-        /// Mark up the the specified <see cref="ReadCursor"/> as consumed.
-        /// </summary>
-        /// <param name="consumed">The <see cref="ReadCursor"/> that points to the position in the <see cref="ReadableBuffer"/> up to where bytes were consumed.</param>
-        public void Consumed(ReadCursor consumed)
-        {
-            ThrowIfNotConsumable();
-            _channel.EndRead(consumed, consumed);
-        }
-
-        /// <summary>
-        /// Mark up the the specified <see cref="ReadCursor"/> as consumed.
-        /// </summary>
-        /// <param name="consumed">The <see cref="ReadCursor"/> that points to the position in the <see cref="ReadableBuffer"/> up to where bytes were consumed.</param>
-        /// <param name="examined">TODO</param>
-        public void Consumed(ReadCursor consumed, ReadCursor examined)
-        {
-            ThrowIfNotConsumable();
-            _channel.EndRead(consumed, examined);
         }
 
         /// <summary>

--- a/src/Channels/ReadableChannel.cs
+++ b/src/Channels/ReadableChannel.cs
@@ -29,10 +29,14 @@ namespace Channels
         public Task Reading => _channel.Reading;
 
         /// <summary>
-        /// 
+        /// Moves forward the channels read cursor to after the consumed data.
         /// </summary>
-        /// <param name="consumed"></param>
-        /// <param name="examined"></param>
+        /// <param name="consumed">Marks the extent of the data that has been succesfully proceesed.</param>
+        /// <param name="examined">Marks the extent of the data that has been read and examined.</param>
+        /// <remarks>
+        /// The memory for the consumed data will be released and no longer available. 
+        /// The examined data communicates to the channel when it should signal more data is available.
+        /// </remarks>
         public void Advance(ReadCursor consumed, ReadCursor examined) => _channel.AdvanceReader(consumed, examined);
 
         /// <summary>

--- a/src/Channels/ReadableChannel.cs
+++ b/src/Channels/ReadableChannel.cs
@@ -29,6 +29,13 @@ namespace Channels
         public Task Reading => _channel.Reading;
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="consumed"></param>
+        /// <param name="examined"></param>
+        public void Advance(ReadCursor consumed, ReadCursor examined) => _channel.Advance(consumed, examined);
+
+        /// <summary>
         /// Signal to the producer that the consumer is done reading.
         /// </summary>
         /// <param name="exception">Optional Exception indicating a failure that's causing the channel to complete.</param>

--- a/src/Channels/ReadableChannel.cs
+++ b/src/Channels/ReadableChannel.cs
@@ -33,7 +33,7 @@ namespace Channels
         /// </summary>
         /// <param name="consumed"></param>
         /// <param name="examined"></param>
-        public void Advance(ReadCursor consumed, ReadCursor examined) => _channel.Advance(consumed, examined);
+        public void Advance(ReadCursor consumed, ReadCursor examined) => _channel.AdvanceReader(consumed, examined);
 
         /// <summary>
         /// Signal to the producer that the consumer is done reading.

--- a/test/Channels.Tests/SocketsFacts.cs
+++ b/test/Channels.Tests/SocketsFacts.cs
@@ -67,12 +67,12 @@ namespace Channels.Tests
                         if (client.Input.Reading.IsCompleted)
                         {
                             reply = input.GetUtf8String();
-                            input.Consumed();
+                            client.Input.Advance(input.End);
                             break;
                         }
                         else
                         {
-                            input.Consumed(input.Start, input.End);
+                            client.Input.Advance(input.Start, input.End);
                         }
                     }
                 }
@@ -162,12 +162,12 @@ namespace Channels.Tests
                     var inputBuffer = await channel.Input.ReadAsync();
                     if (inputBuffer.IsEmpty && channel.Input.Reading.IsCompleted)
                     {
-                        inputBuffer.Consumed(inputBuffer.End);
+                        channel.Input.Advance(inputBuffer.End);
                         break;
                     }
                     if (inputBuffer.Length < 4)
                     {
-                        inputBuffer.Consumed(inputBuffer.Start, inputBuffer.End);
+                        channel.Input.Advance(inputBuffer.Start, inputBuffer.End);
                     }
                     else
                     {
@@ -176,7 +176,7 @@ namespace Channels.Tests
                         {
                             count++;
                         }
-                        inputBuffer.Consumed(inputBuffer.End);
+                        channel.Input.Advance(inputBuffer.End);
                         break;
                     }
                 }
@@ -207,12 +207,12 @@ namespace Channels.Tests
                     var inputBuffer = await channel.Input.ReadAsync();
                     if (inputBuffer.IsEmpty && channel.Input.Reading.IsCompleted)
                     {
-                        inputBuffer.Consumed(inputBuffer.End);
+                        channel.Input.Advance(inputBuffer.End);
                         break;
                     }
                     if (inputBuffer.Length < 4)
                     {
-                        inputBuffer.Consumed(inputBuffer.Start, inputBuffer.End);
+                        channel.Input.Advance(inputBuffer.Start, inputBuffer.End);
                     }
                     else
                     {
@@ -225,7 +225,7 @@ namespace Channels.Tests
                         {
                             break;
                         }
-                        inputBuffer.Consumed(inputBuffer.End);
+                        channel.Input.Advance(inputBuffer.End);
                     }
                 }
                 channel.Input.Complete();
@@ -271,7 +271,7 @@ namespace Channels.Tests
                     ReadableBuffer request = await channel.Input.ReadAsync();
                     if (request.IsEmpty && channel.Input.Reading.IsCompleted)
                     {
-                        request.Consumed();
+                        channel.Input.Advance(request.End);
                         break;
                     }
 
@@ -279,7 +279,7 @@ namespace Channels.Tests
                     var response = channel.Output.Alloc();
                     response.Append(ref request);
                     await response.FlushAsync();
-                    request.Consumed();
+                    channel.Input.Advance(request.End);
                 }
                 channel.Input.Complete();
                 channel.Output.Complete();

--- a/test/Channels.Tests/WritableBufferFacts.cs
+++ b/test/Channels.Tests/WritableBufferFacts.cs
@@ -70,7 +70,7 @@ namespace Channels.Tests
 
                     Assert.True(input.Equals(new Span<byte>(data, offset, input.Length)));
                     offset += input.Length;
-                    input.Consumed();
+                    channel.Advance(input.End);
                 }
                 Assert.Equal(data.Length, offset);
             }
@@ -105,7 +105,7 @@ namespace Channels.Tests
                     string s = ReadableBufferExtensions.GetUtf8String(input);
                     Assert.Equal(data.Substring(offset, input.Length), s);
                     offset += input.Length;
-                    input.Consumed();
+                    channel.Advance(input.End);
                 }
                 Assert.Equal(data.Length, offset);
             }
@@ -139,7 +139,7 @@ namespace Channels.Tests
                     string s = ReadableBufferExtensions.GetAsciiString(input);
                     Assert.Equal(data.Substring(offset, input.Length), s);
                     offset += input.Length;
-                    input.Consumed();
+                    channel.Advance(input.End);
                 }
                 Assert.Equal(data.Length, offset);
             }


### PR DESCRIPTION
- After consuming some data a call to Advance is required
  to make progress
