### PR TITLE
fix some concurrency and `UnownedBuffer` issues

### DIFF
--- a/src/Channels/BufferSegment.cs
+++ b/src/Channels/BufferSegment.cs
@@ -57,12 +57,10 @@ namespace Channels
         // Cloning ctor
         private BufferSegment(IBuffer buffer, int start, int end)
         {
-            Buffer = buffer;
+            Buffer = buffer.Preserve(start, end - start, out start, out end);
             Start = start;
             End = end;
             ReadOnly = true;
-
-            Buffer = Buffer.Preserve(start, end - start);
         }
 
         public void Dispose()

--- a/src/Channels/IBuffer.cs
+++ b/src/Channels/IBuffer.cs
@@ -12,7 +12,9 @@ namespace Channels
         /// </summary>
         /// <param name="offset">The offset to preserve</param>
         /// <param name="length">The length of the buffer to preserve</param>
-        IBuffer Preserve(int offset, int length);
+        /// <param name="newStart">The new starting position of the buffer</param>
+        /// <param name="newEnd">The new ending position of the buffer</param>
+        IBuffer Preserve(int offset, int length, out int newStart, out int newEnd);
 
         /// <summary>
         /// Raw representation of the underlying data this <see cref="IBuffer"/> represents

--- a/src/Channels/OwnedBuffer.cs
+++ b/src/Channels/OwnedBuffer.cs
@@ -23,6 +23,11 @@ namespace Channels
         }
 
         // We're owned, we're always "preserved"
-        public IBuffer Preserve(int offset, int length) => this;
+        public IBuffer Preserve(int offset, int length, out int newStart, out int newEnd)
+        {
+            newStart = 0;
+            newEnd = Data.Length;
+            return this;
+        }
     }
 }

--- a/src/Channels/ReadableBuffer.cs
+++ b/src/Channels/ReadableBuffer.cs
@@ -82,13 +82,13 @@ namespace Channels
             begin = new ReadCursor(segmentHead);
             end = new ReadCursor(segmentTail, segmentTail.End);
 
-            begin.TryGetBuffer(end, out _first, out begin);
-
             _start = begin;
             _end = end;
             _isOwner = true;
 
             _length = buffer._length;
+
+            begin.TryGetBuffer(end, out _first, out begin);
         }
 
         /// <summary>

--- a/src/Channels/ReferenceCountedBuffer.cs
+++ b/src/Channels/ReferenceCountedBuffer.cs
@@ -12,7 +12,7 @@ namespace Channels
 
         protected abstract void DisposeBuffer();
 
-        public IBuffer Preserve(int offset, int count)
+        public IBuffer Preserve(int offset, int count, out int newStart, out int newEnd)
         {
             lock (_lockObj)
             {
@@ -20,6 +20,8 @@ namespace Channels
             }
 
             // Ignore the offset and count, we're just going to reference count the buffer
+            newStart = offset;
+            newEnd = offset + count;
             return this;
         }
 

--- a/src/Channels/UnownedBuffer.cs
+++ b/src/Channels/UnownedBuffer.cs
@@ -24,11 +24,13 @@ namespace Channels
             // GC works
         }
 
-        public IBuffer Preserve(int offset, int length)
+        public IBuffer Preserve(int offset, int length, out int newStart, out int newEnd)
         {
             // Copy to a new Owned Buffer.
             var buffer = new byte[length];
             Buffer.BlockCopy(_buffer.Array, _buffer.Offset + offset, buffer, 0, length);
+            newStart = 0;
+            newEnd = length;
             return new OwnedBuffer(buffer);
         }
     }

--- a/test/Channels.Tests/UnownedBufferChannelFacts.cs
+++ b/test/Channels.Tests/UnownedBufferChannelFacts.cs
@@ -167,6 +167,11 @@ namespace Channels.Tests
 
                 // Never consume, to force buffers to be copied
                 channel.Advance(buffer.Start, buffer.Start.Seek(index));
+
+                // Yield the task. This will ensure that we don't have any Tasks idling
+                // around in UnownedBufferChannel.OnCompleted
+                await Task.Yield();
+
                 index++;
             }
 


### PR DESCRIPTION
issues were found while prototyping a version of aspnet/WebSockets that
uses the `UnownedBufferChannel`.
- `Buffer.Preserve` could change the offsets of the buffer (particularly
  in the case of an unowned buffer being copied to become an owned buffer.
  It needs to be able to pass the new values along
- The `_readWaiting` and `ReadingStarted` gates in `UnownedBufferChannel` were
  being opened simultaneously which caused the first write to be lost
  sometimes. Added a `Task.Yield` to the relevant test to encourage the bug
  to occur.
- `ReadableBuffer`'s cloning constructor was putting the wrong cursor value
  in begin which was causing data to be lost.

/cc @davidfowl @halter73 @pakrym 
