### PR TITLE
Differentiate ReadableBuffer and PreservedBuffer

### DIFF
--- a/samples/Channels.Samples/HttpServer/HttpConnection.Features.cs
+++ b/samples/Channels.Samples/HttpServer/HttpConnection.Features.cs
@@ -112,7 +112,7 @@ namespace Channels.Samples.Http
             {
                 if (_method == null)
                 {
-                    _method = Method.GetAsciiString();
+                    _method = Method.Buffer.GetAsciiString();
                 }
 
                 return _method;
@@ -130,7 +130,7 @@ namespace Channels.Samples.Http
             {
                 if (_path == null)
                 {
-                    _path = Path.GetAsciiString();
+                    _path = Path.Buffer.GetAsciiString();
                 }
                 return _path;
             }

--- a/samples/Channels.Samples/HttpServer/HttpConnection.cs
+++ b/samples/Channels.Samples/HttpServer/HttpConnection.cs
@@ -23,9 +23,9 @@ namespace Channels.Samples.Http
         public RequestHeaderDictionary RequestHeaders => _parser.RequestHeaders;
         public ResponseHeaderDictionary ResponseHeaders { get; } = new ResponseHeaderDictionary();
 
-        public ReadableBuffer HttpVersion => _parser.HttpVersion;
-        public ReadableBuffer Path => _parser.Path;
-        public ReadableBuffer Method => _parser.Method;
+        public PreservedBuffer HttpVersion => _parser.HttpVersion;
+        public PreservedBuffer Path => _parser.Path;
+        public PreservedBuffer Method => _parser.Method;
 
         // TODO: Check the http version
         public bool KeepAlive => true; //RequestHeaders.ContainsKey("Connection") && string.Equals(RequestHeaders["Connection"], "keep-alive");

--- a/samples/Channels.Samples/HttpServer/HttpRequestParser.cs
+++ b/samples/Channels.Samples/HttpServer/HttpRequestParser.cs
@@ -8,9 +8,9 @@ namespace Channels.Samples
     {
         private ParsingState _state;
 
-        public ReadableBuffer HttpVersion { get; set; }
-        public ReadableBuffer Path { get; set; }
-        public ReadableBuffer Method { get; set; }
+        public PreservedBuffer HttpVersion { get; set; }
+        public PreservedBuffer Path { get; set; }
+        public PreservedBuffer Method { get; set; }
 
         public RequestHeaderDictionary RequestHeaders = new RequestHeaderDictionary();
 

--- a/samples/Channels.Samples/HttpServer/RequestHeaderDictionary.cs
+++ b/samples/Channels.Samples/HttpServer/RequestHeaderDictionary.cs
@@ -211,7 +211,7 @@ namespace Channels.Samples.Http
 
         private struct HeaderValue
         {
-            public ReadableBuffer? Raw;
+            public PreservedBuffer? Raw;
             public StringValues? Value;
 
             public StringValues GetValue()
@@ -223,7 +223,7 @@ namespace Channels.Samples.Http
                         return StringValues.Empty;
                     }
 
-                    Value = Raw.Value.GetAsciiString();
+                    Value = Raw.Value.Buffer.GetAsciiString();
                 }
 
                 return Value.Value;

--- a/src/Channels.Networking.Libuv/UvTcpConnection.cs
+++ b/src/Channels.Networking.Libuv/UvTcpConnection.cs
@@ -14,7 +14,7 @@ namespace Channels.Networking.Libuv
         private static readonly Func<UvStreamHandle, int, object, Uv.uv_buf_t> _allocCallback = AllocCallback;
         private static readonly Action<UvWriteReq, int, Exception, object> _writeCallback = WriteCallback;
 
-        private readonly Queue<ReadableBuffer> _outgoing = new Queue<ReadableBuffer>(1);
+        private readonly Queue<PreservedBuffer> _outgoing = new Queue<PreservedBuffer>(1);
 
         protected readonly Channel _input;
         protected readonly Channel _output;

--- a/src/Channels.Networking.Windows.RIO/RioTcpConnection.cs
+++ b/src/Channels.Networking.Windows.RIO/RioTcpConnection.cs
@@ -37,7 +37,7 @@ namespace Channels.Networking.Windows.RIO
 
         private Task _sendTask;
 
-        private ReadableBuffer _sendingBuffer;
+        private PreservedBuffer _sendingBuffer;
         private WritableBuffer _buffer;
 
         internal RioTcpConnection(IntPtr socket, long connectionId, IntPtr requestQueue, RioThread rioThread, RegisteredIO rio)

--- a/src/Channels/Channel.cs
+++ b/src/Channels/Channel.cs
@@ -300,7 +300,7 @@ namespace Channels
                 return new ReadableBuffer(); // Nothing written return empty
             }
 
-            return new ReadableBuffer(new ReadCursor(_commitHead, _commitHeadIndex), new ReadCursor(_writingHead, _writingHead.End), isOwner: false);
+            return new ReadableBuffer(new ReadCursor(_commitHead, _commitHeadIndex), new ReadCursor(_writingHead, _writingHead.End));
         }
 
         private Task CompleteWriteAsync()

--- a/src/Channels/PreservedBuffer.cs
+++ b/src/Channels/PreservedBuffer.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Channels
+{
+    /// <summary>
+    /// Represents a buffer that can read a sequential series of bytes.
+    /// </summary>
+    public struct PreservedBuffer : IDisposable
+    {
+        private ReadableBuffer _buffer;
+
+        internal PreservedBuffer(ref ReadableBuffer buffer)
+        {
+            _buffer = buffer;
+        }
+
+        /// <summary>
+        /// Returns the preserved <see cref="Buffer"/>.
+        /// </summary>
+        public ReadableBuffer Buffer => _buffer;
+
+        /// <summary>
+        /// Dispose the preserved buffer.
+        /// </summary>
+        public void Dispose()
+        {
+            var returnStart = _buffer.Start.Segment;
+            var returnEnd = _buffer.End.Segment;
+
+            while (true)
+            {
+                var returnSegment = returnStart;
+                returnStart = returnStart?.Next;
+                returnSegment?.Dispose();
+
+                if (returnSegment == returnEnd)
+                {
+                    break;
+                }
+            }
+
+            _buffer.ClearCursors();
+        }
+
+    }
+}


### PR DESCRIPTION
Request for comments 

isOwner is through implication
Disposable is not on a type that isn't disposable
If is PreservedBuffer is more clear that you have to dispose.

(Also might be able to shrink both `ReadableBuffer` and `PreservedBuffer` to be register sized structs for no stack copy; but need to profile the side effects)

/cc @davidfowl @mgravell 
