### PR TITLE
Add: public static ReadableBuffer Create(byte[] data, int offset, int length)

### DIFF
--- a/src/Channels/BufferSegment.cs
+++ b/src/Channels/BufferSegment.cs
@@ -55,7 +55,7 @@ namespace Channels
         }
 
         // Cloning ctor
-        private BufferSegment(IBuffer buffer, int start, int end)
+        internal BufferSegment(IBuffer buffer, int start, int end)
         {
             Buffer = buffer.Preserve(start, end - start, out start, out end);
             Start = start;

--- a/src/Channels/OwnedBuffer.cs
+++ b/src/Channels/OwnedBuffer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Buffers;
-using System.Diagnostics;
 
 namespace Channels
 {
@@ -11,23 +10,32 @@ namespace Channels
     {
         private byte[] _buffer;
 
+        /// <summary>
+        /// Create a new instance of <see cref="OwnedBuffer"/> that spans the array provided.
+        /// </summary>
         public OwnedBuffer(byte[] buffer)
         {
             _buffer = buffer;
         }
 
+        /// <summary>
+        /// Raw representation of the underlying data this <see cref="IBuffer"/> represents
+        /// </summary>
         public Memory<byte> Data => new Memory<byte>(_buffer);
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             // No need, the GC can handle it.
         }
 
         // We're owned, we're always "preserved"
+        /// <summary>
+        /// <see cref="IBuffer.Preserve(int, int, out int, out int)"/>
+        /// </summary>
         public IBuffer Preserve(int offset, int length, out int newStart, out int newEnd)
         {
-            newStart = 0;
-            newEnd = Data.Length;
+            newStart = offset;
+            newEnd = offset + length;
             return this;
         }
     }

--- a/src/Channels/ReadableBuffer.cs
+++ b/src/Channels/ReadableBuffer.cs
@@ -469,5 +469,31 @@ namespace Channels
             }
             throw new InvalidOperationException();
         }
+
+
+        /// <summary>
+        /// Create a <see cref="ReadableBuffer"/> over an array.
+        /// </summary>
+        public static ReadableBuffer Create(byte[] data, int offset, int length)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+
+            if(length  < 0 || (offset + length) > data.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            var buffer = new OwnedBuffer(data);
+            var segment = new BufferSegment(buffer, offset, offset + length);
+            return new ReadableBuffer(new ReadCursor(segment, offset), new ReadCursor(segment, offset + length));
+        }
     }
 }

--- a/test/Channels.Tests/ReadableBufferFacts.cs
+++ b/test/Channels.Tests/ReadableBufferFacts.cs
@@ -406,6 +406,45 @@ namespace Channels.Tests
             }
         }
 
+
+        [Fact]
+        public void CanUseArrayBasedReadableBuffers()
+        {
+            var data = Encoding.ASCII.GetBytes("***abc|def|ghijk****"); // note sthe padding here - verifying that it is omitted correctly
+            var buffer = ReadableBuffer.Create(data, 3, data.Length - 7);
+            Assert.Equal(13, buffer.Length);
+            var split = buffer.Split((byte)'|');
+            Assert.Equal(3, split.Count());
+            using (var iter = split.GetEnumerator())
+            {
+                Assert.True(iter.MoveNext());
+                var current = iter.Current;
+                Assert.Equal("abc", current.GetAsciiString());
+                using (var preserved = iter.Current.Preserve())
+                {
+                    Assert.Equal("abc", preserved.Buffer.GetAsciiString());                    
+                }
+
+                Assert.True(iter.MoveNext());
+                current = iter.Current;
+                Assert.Equal("def", current.GetAsciiString());
+                using (var preserved = iter.Current.Preserve())
+                {
+                    Assert.Equal("def", preserved.Buffer.GetAsciiString());
+                }
+
+                Assert.True(iter.MoveNext());
+                current = iter.Current;
+                Assert.Equal("ghijk", current.GetAsciiString());
+                using (var preserved = iter.Current.Preserve())
+                {
+                    Assert.Equal("ghijk", preserved.Buffer.GetAsciiString());
+                }
+
+                Assert.False(iter.MoveNext());
+            }                
+        }
+
         private class NativePool : IBufferPool
         {
             public void Dispose()


### PR DESCRIPTION
Make it easier to create a ReadableBuffer that spans a pre-existing array; fix a bug in OwnedBuffer.Preserve (wrong newStart/newEnd)
