### PR TITLE
No-allocating queue for MemoryPoolBlock in MemoryPool

### DIFF
--- a/src/Channels/MemoryPoolBlock.cs
+++ b/src/Channels/MemoryPoolBlock.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Text;
-using System.Threading;
 
 namespace Channels
 {
@@ -16,7 +15,7 @@ namespace Channels
         private readonly int _length;
 
         public override Memory<byte> Data { get; }
-
+ 
         /// <summary>
         /// This object cannot be instantiated outside of the static Create method
         /// </summary>

--- a/src/Channels/Poolable.cs
+++ b/src/Channels/Poolable.cs
@@ -1,0 +1,274 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Channels
+{
+    /// <summary>
+    /// A base class for any poolable item.
+    /// </summary>
+    public class Poolable
+    {
+        int _id;
+        int _nextId;
+
+        /// <summary>
+        /// A non allocating concurrent pool of any <see cref="Poolable"/>.
+        /// </summary>
+        /// <typeparam name="T">The poolable type.</typeparam>
+        public class ConcurrentPool<T> where T : Poolable
+        {
+            const int None = -1;
+
+            /// <summary>
+            /// Thread-safe collection of blocks which are currently in the pool. A slab will pre-allocate all of the item tracking objects
+            /// and add them to this collection. When memory is requested it is taken from here first, and when it is returned it is re-added.
+            /// </summary>
+            private readonly ObjectIdentityMap<T> _items = new ObjectIdentityMap<T>();
+
+            long _blocksHead = None;
+
+            public void RegisterForPooling(T block)
+            {
+                block._id = _items.Put(block);
+            }
+
+            public void Enqueue(T item)
+            {
+                if (TryEnqueue(item))
+                {
+                    return;
+                }
+
+                var sw = new SpinWait();
+                do
+                {
+                    sw.SpinOnce();
+                } while (TryEnqueue(item));
+            }
+
+            bool TryEnqueue(T block)
+            {
+                var current = Volatile.Read(ref _blocksHead);
+                int abaCounter;
+                int blockId;
+                Decode(current, out abaCounter, out blockId);
+
+                block._nextId = blockId;
+
+                unchecked { abaCounter += 1; }
+
+                return Interlocked.CompareExchange(ref _blocksHead, Encode(abaCounter, block._id), current) == current;
+            }
+
+            public bool TryDequeue(out T item)
+            {
+                // optimistic path
+                var current = Volatile.Read(ref _blocksHead);
+
+                int abaCounter;
+                int blockId;
+                Decode(current, out abaCounter, out blockId);
+                if (blockId == None)
+                {
+                    item = null;
+                    return false;
+                }
+
+                item = _items.TryRetrieve(blockId);
+
+                unchecked { abaCounter += 1; }
+
+                if (Interlocked.CompareExchange(ref _blocksHead, Encode(abaCounter, item._nextId), current) == current)
+                {
+                    return true;
+                }
+
+                // start spinning
+                var sw = new SpinWait();
+                sw.SpinOnce();
+                do
+                {
+                    current = Volatile.Read(ref _blocksHead);
+                    Decode(current, out abaCounter, out blockId);
+                    if (blockId == None)
+                    {
+                        item = null;
+                        return false;
+                    }
+                    item = _items.TryRetrieve(blockId);
+                    unchecked { abaCounter += 1; }
+                } while (Interlocked.CompareExchange(ref _blocksHead, Encode(abaCounter, item._nextId), current) != current);
+
+                return true;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static unsafe void Decode(long value, out int abaCounter, out int blockId)
+            {
+                var i = (int*)&value;
+                abaCounter = *i;
+                blockId = *(i + 1);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static unsafe long Encode(int abaCounter, int blockId)
+            {
+                long result = 0;
+                var i = (int*)&result;
+
+                *i = abaCounter;
+                *(i + 1) = blockId;
+
+                return result;
+            }
+        }
+
+    /// <summary>
+    /// A map providing a two way mapping between an object and int identifier.
+    /// </summary>
+    class ObjectIdentityMap<T>
+        where T : class
+    {
+        private volatile Segment _head;
+        private volatile Segment _tail;
+        private const int SegmentSize = 1024;
+        private const int InSegmentMask = SegmentSize - 1;
+    
+        public ObjectIdentityMap()
+        {
+            _head = _tail = new Segment(0, this);
+        }
+
+        /// <summary>
+        /// Puts and item returning its index.
+        /// </summary>
+        public int Put(T item)
+        {
+            var sw = new SpinWait();
+            while (true)
+            {
+                var tail = _tail;
+                int index;
+                if (tail.TryAppend(item, out index))
+                {
+                    return index;
+                }
+                sw.SpinOnce();
+            }
+        }
+
+        /// <summary>
+        /// Tries to retrieve a specified item.
+        /// </summary>
+        public T TryRetrieve(int index)
+        {
+            return _head.TryRetrieve(index);
+        }
+
+        /// <summary>
+        /// private class for ConcurrentQueue. 
+        /// a queue is a linked list of small arrays, each node is called a segment.
+        /// A segment contains an array, a pointer to the next segment, and _low, _high indices recording
+        /// the first and last valid elements of the array.
+        /// </summary>
+        private class Segment
+        {
+            private volatile T[] _items;
+            private volatile Segment _next;
+            private readonly int _index;
+            private volatile int _previousFreePosition;
+            private volatile ObjectIdentityMap<T> _source;
+
+            /// <summary>
+            /// Create and initialize a segment with the specified index.
+            /// </summary>
+            internal Segment(int index, ObjectIdentityMap<T> source)
+            {
+                _items = new T[SegmentSize];
+                _previousFreePosition = -1;
+                _index = index;
+                _source = source;
+            }
+
+            /// <summary>
+            /// Create a new segment and append to the current one
+            /// Update the m_tail pointer
+            /// This method is called when there is no contention
+            /// </summary>
+            private void Grow()
+            {
+                //no CAS is needed, since there is no contention (other threads are blocked, busy waiting)
+                var newSegment = new Segment(_index + 1, _source);  //m_index is Int64, we don't need to worry about overflow
+                _next = newSegment;
+                _source._tail = _next;
+            }
+
+            /// <summary>
+            /// Try to append an element at the end of this segment.
+            /// </summary>
+            /// <param name="value">the element to append</param>
+            /// <param name="index"></param>
+            /// <returns>true if the element is appended, false if the current segment is full</returns>
+            /// <remarks>if appending the specified element succeeds, and after which the segment is full, 
+            /// then grow the segment</remarks>
+            internal bool TryAppend(T value, out int index)
+            {
+                index = 0;
+
+                //quickly check if buffer is already full, if so, return
+                if (_previousFreePosition >= SegmentSize - 1)
+                {
+                    return false;
+                }
+
+                int i;
+
+                //We need do Interlocked.Increment and value/state update in a finally block to ensure that they run
+                //without interuption. This is to prevent anything from happening between them, and another dequeue
+                //thread maybe spinning forever to wait for _items[] to be set;
+                try
+                { }
+                finally
+                {
+                    i = Interlocked.Increment(ref _previousFreePosition);
+                    if (i <= SegmentSize - 1)
+                    {
+                        index = _index*SegmentSize + i;
+                        Volatile.Write(ref _items[i], value);
+                    }
+
+                    //if this thread takes up the last slot in the segment, then this thread is responsible
+                    //to grow a new segment. Calling Grow must be in the finally block too for reliability reason:
+                    //if thread abort during Grow, other threads will be left busy spinning forever.
+                    if (i == SegmentSize - 1)
+                    {
+                        Grow();
+                    }
+                }
+
+                //if newhigh <= SegmentSize-1, it means the current thread successfully takes up a spot
+                return i <= SegmentSize - 1;
+            }
+
+            public T TryRetrieve(int index)
+            {
+                var count = index/SegmentSize;
+                var @this = this;
+
+                // move forward
+                for (var i = 0; i < count; i++)
+                {
+                    @this = @this._next;
+                    if (@this == null)
+                    {
+                        return null;
+                    }
+                }
+
+                return Volatile.Read(ref @this._items[index & InSegmentMask]);
+            }
+        }
+    }
+
+    }
+}

--- a/src/Channels/ReferenceCountedBuffer.cs
+++ b/src/Channels/ReferenceCountedBuffer.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace Channels
 {
-    public abstract class ReferenceCountedBuffer : IBuffer
+    public abstract class ReferenceCountedBuffer : Poolable, IBuffer
     {
         private object _lockObj = new object();
         private int _referenceCount = 1;

--- a/test/Channels.Tests.Performance/ConcurrentPoolBenchmark.cs
+++ b/test/Channels.Tests.Performance/ConcurrentPoolBenchmark.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnostics.Windows;
+using BenchmarkDotNet.Jobs;
+
+namespace Channels.Tests.Performance
+{
+    [Config(typeof(Config))]
+    public class ConcurrentPoolBenchmark
+    {
+        public class Config : ManualConfig
+        {
+            public Config()
+            {
+                Add(Job.Default.
+                    With(Platform.X64).
+                    With(Jit.RyuJit).
+                    With(Runtime.Clr).
+                    WithIterationTime(200). // 200ms per iteration
+                    WithWarmupCount(5).
+                    WithTargetCount(10));
+                Add(new MemoryDiagnoser());
+            }
+        }
+
+        public const int InnerLoopCount = 100;
+        const int Count = 4096;
+
+        public ChannelFactory ChannelFactory;
+        public Poolable.ConcurrentPool<Poolable> Pool;
+        public ConcurrentQueue<Poolable> BaselineQueue;
+
+        [Setup]
+        public void Setup()
+        {
+            if (Pool == null)
+            {
+                Pool = new Poolable.ConcurrentPool<Poolable>();
+                // preallocate
+                for (var i = 0; i < Count; i++)
+                {
+                    var poolable = new Poolable();
+                    Pool.RegisterForPooling(poolable);
+                    Pool.Enqueue(poolable);
+                }
+
+                BaselineQueue = new ConcurrentQueue<Poolable>();
+
+                // preallocate
+                for (var i = 0; i < Count; i++)
+                {
+                    BaselineQueue.Enqueue(new Poolable());
+                }
+
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        public void Leases()
+        {
+            for (var i = 0; i < InnerLoopCount; i++)
+            {
+                Poolable item;
+                if (Pool.TryDequeue(out item))
+                {
+                    Pool.Enqueue(item);
+                }
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount, Baseline = true)]
+        public void BaseLine()
+        {
+            for (var i = 0; i < InnerLoopCount; i++)
+            {
+                Poolable item;
+                if (BaselineQueue.TryDequeue(out item))
+                {
+                    BaselineQueue.Enqueue(item);
+                }
+            }
+        }
+    }
+}

--- a/test/Channels.Tests.Performance/Program.cs
+++ b/test/Channels.Tests.Performance/Program.cs
@@ -32,6 +32,10 @@ namespace Channels.Tests.Performance
             {
                 BenchmarkRunner.Run<ChannelsStreamsBenchmark>();
             }
+            if (type.HasFlag(BenchmarkType.ConcurrentPool))
+            {
+                BenchmarkRunner.Run<ConcurrentPoolBenchmark>();
+            }
         }
     }
 
@@ -40,6 +44,7 @@ namespace Channels.Tests.Performance
     {
         Streams = 1,
         // add new ones in powers of two - e.g. 2,4,8,16...
+        ConcurrentPool = 2,
 
         All = uint.MaxValue
     }

--- a/test/Channels.Tests/ConcurrentPoolFacts.cs
+++ b/test/Channels.Tests/ConcurrentPoolFacts.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Channels.Tests
+{
+    public class ConcurrentPoolFacts
+    {
+        const int Count = 4096;
+        const int NumberOfTasks = 2;
+        const int SingleTaskBlockCount = Count / NumberOfTasks;
+
+        [Fact]
+        public async Task WorkWithConcurrentAccess()
+        {
+            var pool = new Poolable.ConcurrentPool<Poolable>();
+
+            for (var i = 0; i < Count; i++)
+            {
+                var poolable = new Poolable();
+                pool.RegisterForPooling(poolable);
+                pool.Enqueue(poolable);
+            }
+
+            var @wait = new ManualResetEventSlim();
+
+            var tasks = new Task<Poolable[]>[NumberOfTasks];
+            for (var i = 0; i < NumberOfTasks; i++)
+            {
+                tasks[i] = Lease(wait, pool);
+            }
+
+            var all = Task.WhenAll(tasks);
+            @wait.Set();
+
+            var results = await all;
+            var allBuffers = results.Aggregate(new HashSet<Poolable>(), (h1, h2) =>
+            {
+                h1.UnionWith(h2);
+                return h1;
+            });
+
+            Assert.Equal(Count, allBuffers.Count);
+        }
+
+        /// <summary>
+        /// Just leases <see cref="SingleTaskBlockCount"/> items from <paramref name="pool"/> and returns it.
+        /// </summary>
+        static Task<Poolable[]> Lease(ManualResetEventSlim wait, Poolable.ConcurrentPool<Poolable> pool)
+        {
+            return Task.Run(() =>
+            {
+                var items = new Poolable[SingleTaskBlockCount];
+                @wait.Wait();
+                for (var i = 0; i < SingleTaskBlockCount; i++)
+                {
+                    Poolable item;
+                    Assert.True(pool.TryDequeue(out item));
+                    items[i] = item;
+                }
+                return items;
+            });
+        }
+    }
+}


### PR DESCRIPTION
This `PR` provides a custom no-allocating queue for `MemoryPoolBlock` in the `MemoryPool`. 

It works in a bit different way from the `ConcurrentQueue<T>`. The `ConcurrentQueue<T>` uses segments of length `32` and status fields to mark an item as published. These segments requires allocations though.

This PR adds a `Poolable` class that has a private field representing an identifier of the next block, which enables creation of a concurrent store from the blocks themselves. To address ABA problem, instead of blocks references, their `int` identifiers are used, which combined with `int` `abaCounter` can be exchange in one operation using `Interlocked.CompareExchange( ref long, long, long)`.

This PR adds a benchmark for performance and memory allocations. 

| Method | Median | StdDev | Scaled | Scaled-SD | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| PR | 51.4403 ns | 2.8007 ns | 1.00 | 0.07 | - | - | - | 0.00 |
| ConcurrentQueue | 51.6737 ns | 3.1264 ns | 1.00 | 0.00 | 141.63 | 60.70 | 20.23 | 5.45 |
