### PR TITLE
Various Channel improvements

### DIFF
--- a/src/Channels.Text.Primitives/ReadableBufferExtensions.cs
+++ b/src/Channels.Text.Primitives/ReadableBufferExtensions.cs
@@ -37,6 +37,38 @@ namespace Channels.Text.Primitives
             return buffer.Slice(start);
         }
 
+        /// <summary>
+        /// Trim whitespace starting from the specified <see cref="ReadableBuffer"/>.
+        /// </summary>
+        /// <param name="buffer">The <see cref="ReadableBuffer"/> to trim</param>
+        /// <returns>A new <see cref="ReadableBuffer"/> with the starting whitespace trimmed.</returns>
+        public static ReadableBuffer TrimEnd(this ReadableBuffer buffer)
+        {
+            var end = -1;
+            var i = 0;
+            foreach (var memory in buffer)
+            {
+                var span = memory.Span;
+                for (int j = 0; j < span.Length; j++)
+                {
+                    i++;
+                    if (IsWhitespaceChar(span[j]))
+                    {
+                        if (end == -1)
+                        {
+                            end = i;
+                        }
+                    }
+                    else
+                    {
+                        end = -1;
+                    }
+                }
+            }
+
+            return end != -1 ? buffer.Slice(0, end - 1) : buffer;
+        }
+
         private static bool IsWhitespaceChar(int ch)
         {
             return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';

--- a/src/Channels/ChannelExtensions.cs
+++ b/src/Channels/ChannelExtensions.cs
@@ -68,6 +68,11 @@ namespace Channels
             return new ValueTask<int>(input.ReadAsyncAwaited(destination));
         }
 
+        public static async Task<ReadableBuffer> ReadBufferAsync(this IReadableChannel input)
+        {
+            return (await input.ReadAsync()).Buffer;
+        }
+
         public static Task CopyToAsync(this IReadableChannel input, Stream stream)
         {
             return input.CopyToAsync(stream, 4096, CancellationToken.None);

--- a/src/Channels/ChannelExtensions.cs
+++ b/src/Channels/ChannelExtensions.cs
@@ -68,11 +68,6 @@ namespace Channels
             return new ValueTask<int>(input.ReadAsyncAwaited(destination));
         }
 
-        public static async Task<ReadableBuffer> ReadBufferAsync(this IReadableChannel input)
-        {
-            return (await input.ReadAsync()).Buffer;
-        }
-
         public static Task CopyToAsync(this IReadableChannel input, Stream stream)
         {
             return input.CopyToAsync(stream, 4096, CancellationToken.None);

--- a/src/Channels/MemoryEnumerator.cs
+++ b/src/Channels/MemoryEnumerator.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections;
-using System.Collections.Generic;
 
 namespace Channels
 {
@@ -19,7 +17,7 @@ namespace Channels
         /// <summary>
         /// 
         /// </summary>
-        public MemoryEnumerator(ref ReadCursor start, ref ReadCursor end)
+        public MemoryEnumerator(ReadCursor start, ReadCursor end)
         {
             _startIndex = start.Index;
             _segment = start.Segment;

--- a/src/Channels/ReadableBuffer.cs
+++ b/src/Channels/ReadableBuffer.cs
@@ -355,7 +355,7 @@ namespace Channels
         /// </summary>
         public MemoryEnumerator GetEnumerator()
         {
-            return new MemoryEnumerator(ref _start, ref _end);
+            return new MemoryEnumerator(_start, _end);
         }
 
         /// <summary>
@@ -465,6 +465,19 @@ namespace Channels
                 return offset + 7;
             }
             throw new InvalidOperationException();
+        }
+
+        /// <summary>
+        /// Create a <see cref="ReadableBuffer"/> over an array.
+        /// </summary>
+        public static ReadableBuffer Create(byte[] data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            return Create(data, 0, data.Length);
         }
 
         /// <summary>

--- a/test/Channels.Tests/ReadableBufferFacts.cs
+++ b/test/Channels.Tests/ReadableBufferFacts.cs
@@ -144,6 +144,32 @@ namespace Channels.Tests
         }
 
         [Theory]
+        [InlineData("hello ", "hello")]
+        [InlineData("hello    ", "hello")]
+        [InlineData("hello \r\n", "hello")]
+        [InlineData("he  llo\r", "he  llo")]
+        [InlineData(" hell o\t", " hell o")]
+        public async Task TrimEndTrimsWhitespaceAtEnd(string input, string expected)
+        {
+            using (var cf = new ChannelFactory())
+            {
+                var channel = cf.CreateChannel();
+
+                var writeBuffer = channel.Alloc();
+                var bytes = Encoding.ASCII.GetBytes(input);
+                writeBuffer.Write(bytes);
+                await writeBuffer.FlushAsync();
+
+                var result = await channel.ReadAsync();
+                var buffer = result.Buffer;
+                var trimmed = buffer.TrimEnd();
+                var outputBytes = trimmed.ToArray();
+
+                Assert.Equal(expected, Encoding.ASCII.GetString(outputBytes));
+            }
+        }
+
+        [Theory]
         [InlineData("foo\rbar\r\n", "\r\n", "foo\rbar")]
         [InlineData("foo\rbar\r\n", "\rbar", "foo")]
         [InlineData("/pathpath/", "path/", "/path")]


### PR DESCRIPTION
Add `ReadableBuffer.TrimEnd`
Add location we are consuming from to `Already consuming.` error message.
Add `ReadBufferAsync` extension method that returns buffer immediately.
Add `ReadableBufferCreate(byte[])`
