### PR TITLE
ReadableBuffer implements ISequence<ReadOnlyMemory<byte>>

### DIFF
--- a/src/Channels/project.json
+++ b/src/Channels/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "0.2.0-beta-*",
   "description": "An abstraction for doing efficient asynchronous IO",
   "packOptions": {
@@ -17,7 +17,8 @@
     "System.Buffers": "4.0.0",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0",
     "System.Numerics.Vectors": "4.1.1",
-    "System.Threading.Tasks.Extensions": "4.0.0"
+    "System.Threading.Tasks.Extensions": "4.0.0",
+    "System.Collections.Sequences": "0.1.0-e161028-1"
   },
 
   "frameworks": {

--- a/test/Channels.Tests/project.json
+++ b/test/Channels.Tests/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
@@ -21,7 +21,8 @@
     "Channels.Networking.Windows.RIO": {
       "target": "project"
     },
-    "xunit": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta2-build3300",
+    "System.Collections.Sequences": "0.1.0-e161103-1"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
This will allow to use reusable routines operating over multi-segment structures to process data
in readable buffers.