### PR TITLE
ReadableBufferExtensions.GetUInt32 now works over sequences of ReadOnlyMemory<T>

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121"
+    "version": "1.0.0-preview2-003131"
   }
 }

--- a/src/Channels/ReadableBuffer.cs
+++ b/src/Channels/ReadableBuffer.cs
@@ -27,6 +27,8 @@ namespace Channels
         /// </summary>
         public int Length => _length >= 0 ? _length : GetLength();
 
+        int? ISequence<ReadOnlyMemory<byte>>.Length => _length >= 0 ? _length : (int?)null;
+
         /// <summary>
         /// Determines if the <see cref="ReadableBuffer"/> is empty.
         /// </summary>
@@ -552,6 +554,11 @@ namespace Channels
         SequenceEnumerator<ReadOnlyMemory<byte>> ISequence<ReadOnlyMemory<byte>>.GetEnumerator()
         {
             return new SequenceEnumerator<ReadOnlyMemory<byte>>(this);
+        }
+
+        bool ISequence<ReadOnlyMemory<byte>>.TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Channels/project.json
+++ b/src/Channels/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "0.2.0-beta-*",
   "description": "An abstraction for doing efficient asynchronous IO",
   "packOptions": {
@@ -17,7 +17,8 @@
     "System.Buffers": "4.0.0",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0",
     "System.Numerics.Vectors": "4.1.1",
-    "System.Threading.Tasks.Extensions": "4.0.0"
+    "System.Threading.Tasks.Extensions": "4.0.0",
+    "System.Collections.Sequences": "0.1.0-e161028-1"
   },
 
   "frameworks": {

--- a/src/Channels/project.json
+++ b/src/Channels/project.json
@@ -18,7 +18,7 @@
     "System.Runtime.CompilerServices.Unsafe": "4.0.0",
     "System.Numerics.Vectors": "4.1.1",
     "System.Threading.Tasks.Extensions": "4.0.0",
-    "System.Collections.Sequences": "0.1.0-e161028-1"
+    "System.Collections.Sequences": "0.1.0-e161104-5"
   },
 
   "frameworks": {

--- a/test/Channels.Tests/project.json
+++ b/test/Channels.Tests/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
@@ -21,7 +21,8 @@
     "Channels.Networking.Windows.RIO": {
       "target": "project"
     },
-    "xunit": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta2-build3300",
+    "System.Collections.Sequences": "0.1.0-e161103-1"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Channels.Tests/project.json
+++ b/test/Channels.Tests/project.json
@@ -22,7 +22,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta2-build3300",
-    "System.Collections.Sequences": "0.1.0-e161103-1"
+    "System.Collections.Sequences": "0.1.0-e161104-5"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
In addition, I optimized the method a bit. It was heap allocating in cases where the first segment 
was too short to parse an int and the second was too long for them both to fit in 128 bytes. 
Now, the algorithm is "optimistic". It tries to parse without allocating, and only allocates when it fails.
